### PR TITLE
Custom ruby module and engine patching/detouring

### DIFF
--- a/Game/AriMath.cpp
+++ b/Game/AriMath.cpp
@@ -1,13 +1,14 @@
 #include "AriMath.h"
+#include "MemoryUtil.h"
 #include "RubyCommon.h"
 
 namespace RubyModule {
-VALUE ARI_MATH{};
+RB_VALUE ARI_MATH{};
 constexpr double PI = 3.141592653589793238463;
 constexpr double PI2 = PI * 2.0;
 constexpr double BOUNCE_CONSTANT = PI2 / 3.0;
 
-static VALUE clamp(VALUE object, VALUE _x, VALUE _min, VALUE _max) {
+static RB_VALUE arimath_clamp(RB_VALUE object, RB_VALUE _x, RB_VALUE _min, RB_VALUE _max) {
     auto* common = Ruby::Common::Get();
 
     auto x = common->GetFloat(_x);
@@ -21,7 +22,7 @@ static VALUE clamp(VALUE object, VALUE _x, VALUE _min, VALUE _max) {
     return _x;
 }
 
-static VALUE min(VALUE object, VALUE _lhs, VALUE _rhs) {
+static RB_VALUE arimath_min(RB_VALUE object, RB_VALUE _lhs, RB_VALUE _rhs) {
     auto* common = Ruby::Common::Get();
     auto lhs = common->GetFloat(_lhs);
     auto rhs = common->GetFloat(_rhs);
@@ -31,7 +32,7 @@ static VALUE min(VALUE object, VALUE _lhs, VALUE _rhs) {
     return _lhs;
 }
 
-static VALUE max(VALUE object, VALUE _lhs, VALUE _rhs) {
+static RB_VALUE arimath_max(RB_VALUE object, RB_VALUE _lhs, RB_VALUE _rhs) {
     auto* common = Ruby::Common::Get();
     auto lhs = common->GetFloat(_lhs);
     auto rhs = common->GetFloat(_rhs);
@@ -41,7 +42,7 @@ static VALUE max(VALUE object, VALUE _lhs, VALUE _rhs) {
     return _rhs;
 }
 
-static VALUE ease_out_elastic(VALUE object, VALUE _t) {
+static RB_VALUE arimath_ease_out_elastic(RB_VALUE object, RB_VALUE _t) {
     auto* common = Ruby::Common::Get();
     auto t = common->GetFloat(_t)->GetValue();
 
@@ -55,7 +56,7 @@ static VALUE ease_out_elastic(VALUE object, VALUE _t) {
     return common->MakeFloat(bounce);
 }
 
-static VALUE lerp(VALUE object, VALUE _v0, VALUE _v1, VALUE _t) {
+static RB_VALUE arimath_lerp(RB_VALUE object, RB_VALUE _v0, RB_VALUE _v1, RB_VALUE _t) {
     auto* common = Ruby::Common::Get();
     const auto v0 = common->GetFloat(_v0)->GetValue();
     const auto v1 = common->GetFloat(_v1)->GetValue();
@@ -64,8 +65,8 @@ static VALUE lerp(VALUE object, VALUE _v0, VALUE _v1, VALUE _t) {
     return common->MakeFloat((1.0 - t) * v0 + t * v1);
 }
 
-static VALUE remap_range(VALUE object, VALUE _a_low, VALUE _a_high, VALUE _b_low, VALUE _b_high,
-                         VALUE _x) {
+static RB_VALUE arimath_remap_range(RB_VALUE object, RB_VALUE _a_low, RB_VALUE _a_high,
+                                    RB_VALUE _b_low, RB_VALUE _b_high, RB_VALUE _x) {
     auto* common = Ruby::Common::Get();
     const auto a_low = common->GetFloat(_a_low)->GetValue();
     const auto a_high = common->GetFloat(_a_high)->GetValue();
@@ -76,7 +77,7 @@ static VALUE remap_range(VALUE object, VALUE _a_low, VALUE _a_high, VALUE _b_low
     return common->MakeFloat(b_low + ((x - a_low) * (b_high - b_low) / (a_high - a_low)));
 }
 
-static VALUE norm_to_circle(VALUE object, VALUE _angle) {
+static RB_VALUE arimath_norm_to_circle(RB_VALUE object, RB_VALUE _angle) {
     auto* common = Ruby::Common::Get();
     auto angle = common->GetFloat(_angle)->GetValue();
 
@@ -99,14 +100,15 @@ void RegisterAriMath() {
         common->DefineConst(ARI_MATH, "PI2", common->MakeFloat(PI2));
 
         // Methods
-        common->DefineModuleFunction(ARI_MATH, "clamp", &RubyModule::clamp, 3);
-        common->DefineModuleFunction(ARI_MATH, "min", &RubyModule::min, 2);
-        common->DefineModuleFunction(ARI_MATH, "max", &RubyModule::max, 2);
-        common->DefineModuleFunction(ARI_MATH, "ease_out_elastic", &RubyModule::ease_out_elastic,
-                                     1);
-        common->DefineModuleFunction(ARI_MATH, "lerp", &RubyModule::lerp, 3);
-        common->DefineModuleFunction(ARI_MATH, "remap_range", &RubyModule::remap_range, 5);
-        common->DefineModuleFunction(ARI_MATH, "norm_to_circle", &RubyModule::norm_to_circle, 1);
+        common->DefineModuleFunction(ARI_MATH, "clamp", &RubyModule::arimath_clamp, 3);
+        common->DefineModuleFunction(ARI_MATH, "min", &RubyModule::arimath_min, 2);
+        common->DefineModuleFunction(ARI_MATH, "max", &RubyModule::arimath_max, 2);
+        common->DefineModuleFunction(ARI_MATH, "ease_out_elastic",
+                                     &RubyModule::arimath_ease_out_elastic, 1);
+        common->DefineModuleFunction(ARI_MATH, "lerp", &RubyModule::arimath_lerp, 3);
+        common->DefineModuleFunction(ARI_MATH, "remap_range", &RubyModule::arimath_remap_range, 5);
+        common->DefineModuleFunction(ARI_MATH, "norm_to_circle",
+                                     &RubyModule::arimath_norm_to_circle, 1);
     }
 }
 

--- a/Game/AriMath.cpp
+++ b/Game/AriMath.cpp
@@ -1,0 +1,113 @@
+#include "AriMath.h"
+#include "RubyCommon.h"
+
+namespace RubyModule {
+VALUE ARI_MATH{};
+constexpr double PI = 3.141592653589793238463;
+constexpr double PI2 = PI * 2.0;
+constexpr double BOUNCE_CONSTANT = PI2 / 3.0;
+
+static VALUE clamp(VALUE object, VALUE _x, VALUE _min, VALUE _max) {
+    auto* common = Ruby::Common::Get();
+
+    auto x = common->GetFloat(_x);
+    auto min = common->GetFloat(_min);
+    auto max = common->GetFloat(_max);
+    if (x->GetValue() > max->GetValue()) {
+        return _max;
+    } else if (x->GetValue() < min->GetValue()) {
+        return _min;
+    }
+    return _x;
+}
+
+static VALUE min(VALUE object, VALUE _lhs, VALUE _rhs) {
+    auto* common = Ruby::Common::Get();
+    auto lhs = common->GetFloat(_lhs);
+    auto rhs = common->GetFloat(_rhs);
+    if (lhs->GetValue() > rhs->GetValue()) {
+        return _rhs;
+    }
+    return _lhs;
+}
+
+static VALUE max(VALUE object, VALUE _lhs, VALUE _rhs) {
+    auto* common = Ruby::Common::Get();
+    auto lhs = common->GetFloat(_lhs);
+    auto rhs = common->GetFloat(_rhs);
+    if (lhs->GetValue() > rhs->GetValue()) {
+        return _lhs;
+    }
+    return _rhs;
+}
+
+static VALUE ease_out_elastic(VALUE object, VALUE _t) {
+    auto* common = Ruby::Common::Get();
+    auto t = common->GetFloat(_t)->GetValue();
+
+    if (t < 0.0) {
+        return common->MakeFloat(0.0);
+    } else if (t > 1.0) {
+        return common->MakeFloat(1.0);
+    }
+
+    const double bounce = pow(2.0, (-10.0 * t)) * sin((t * 10.0 - 0.75) * BOUNCE_CONSTANT) + 1.0;
+    return common->MakeFloat(bounce);
+}
+
+static VALUE lerp(VALUE object, VALUE _v0, VALUE _v1, VALUE _t) {
+    auto* common = Ruby::Common::Get();
+    const auto v0 = common->GetFloat(_v0)->GetValue();
+    const auto v1 = common->GetFloat(_v1)->GetValue();
+    const auto t = common->GetFloat(_t)->GetValue();
+
+    return common->MakeFloat((1.0 - t) * v0 + t * v1);
+}
+
+static VALUE remap_range(VALUE object, VALUE _a_low, VALUE _a_high, VALUE _b_low, VALUE _b_high,
+                         VALUE _x) {
+    auto* common = Ruby::Common::Get();
+    const auto a_low = common->GetFloat(_a_low)->GetValue();
+    const auto a_high = common->GetFloat(_a_high)->GetValue();
+    const auto b_low = common->GetFloat(_b_low)->GetValue();
+    const auto b_high = common->GetFloat(_a_high)->GetValue();
+    const auto x = common->GetFloat(_x)->GetValue();
+
+    return common->MakeFloat(b_low + ((x - a_low) * (b_high - b_low) / (a_high - a_low)));
+}
+
+static VALUE norm_to_circle(VALUE object, VALUE _angle) {
+    auto* common = Ruby::Common::Get();
+    auto angle = common->GetFloat(_angle)->GetValue();
+
+    angle = fmod(angle, 360.0);
+    while (angle < 0.0) {
+        angle += 360.0;
+    }
+
+    return common->MakeFloat(angle);
+}
+
+void RegisterAriMath() {
+    auto* common = Ruby::Common::Get();
+    if (!ARI_MATH) {
+        ARI_MATH = common->DefineModule("AriMath");
+
+        // Consts
+        common->DefineConst(ARI_MATH, "BOUNCE_CONST", common->MakeFloat(BOUNCE_CONSTANT));
+        common->DefineConst(ARI_MATH, "PI", common->MakeFloat(PI));
+        common->DefineConst(ARI_MATH, "PI2", common->MakeFloat(PI2));
+
+        // Methods
+        common->DefineModuleFunction(ARI_MATH, "clamp", &RubyModule::clamp, 3);
+        common->DefineModuleFunction(ARI_MATH, "min", &RubyModule::min, 2);
+        common->DefineModuleFunction(ARI_MATH, "max", &RubyModule::max, 2);
+        common->DefineModuleFunction(ARI_MATH, "ease_out_elastic", &RubyModule::ease_out_elastic,
+                                     1);
+        common->DefineModuleFunction(ARI_MATH, "lerp", &RubyModule::lerp, 3);
+        common->DefineModuleFunction(ARI_MATH, "remap_range", &RubyModule::remap_range, 5);
+        common->DefineModuleFunction(ARI_MATH, "norm_to_circle", &RubyModule::norm_to_circle, 1);
+    }
+}
+
+} // namespace RubyModule

--- a/Game/AriMath.h
+++ b/Game/AriMath.h
@@ -1,0 +1,8 @@
+#pragma once
+namespace Ruby {
+class Common;
+}
+
+namespace RubyModule {
+void RegisterAriMath();
+} // namespace RubyModule

--- a/Game/Common.h
+++ b/Game/Common.h
@@ -1,0 +1,2 @@
+#pragma once
+#define LOG(x) MessageBox(NULL, x, "RGSSAD Container", MB_ICONERROR)

--- a/Game/EnginePatches.cpp
+++ b/Game/EnginePatches.cpp
@@ -75,17 +75,17 @@ void PatchDebugPresent() {
     if (kernel32 == 0) {
         return;
     }
-    auto addr = GetProcAddress(kernel32, "IsDebuggerPresent");
+    auto addr = reinterpret_cast<uintptr_t>(GetProcAddress(kernel32, "IsDebuggerPresent"));
     if (addr == 0) {
         return;
     }
 
     // EAX stores the return of IsDebuggerPresent()
-    std::array<char, 3> patch{
+    static constexpr std::array<char, 3> patch{
         '\x31', '\xC0', // xor eax, eax
         '\xC3'          // ret
     };
-    MemoryUtil::PatchBytes(reinterpret_cast<DWORD>(addr), patch.data(), patch.size());
+    MemoryUtil::PatchBytes(addr, patch.data(), patch.size());
 }
 
 } // namespace Patches

--- a/Game/EnginePatches.cpp
+++ b/Game/EnginePatches.cpp
@@ -21,14 +21,16 @@ MallocType RGSSAD_MALLOC = nullptr;
 */
 
 void SetupDetours(const char* library_path) {
-    Ruby::Common::Get()->AddNewModule(&RubyModule::RegisterAriMath);
-    Ruby::Common::Get()->Initialize(library_path);
+    auto* common = Ruby::Common::Get();
+    common->AddNewModule(&RubyModule::RegisterAriMath);
+    common->Initialize(library_path);
 }
 
 /* Encryption key swap */
 constexpr std::array<char, 8> PATCHED_HEADER{'\x31', '\xac', '\x3e', '\x2d',
                                              '\x9b', '\x23', '\xda', '\x11'};
 constexpr unsigned int NEW_KEY = 0xBCF33B95;
+
 void SwapRgssadEncryption(const char* library_path) {
     MemoryUtil::SigScanner scanner(library_path);
     // Locate the RGSSAD header to change the bytes to something else. The fields for the header are

--- a/Game/EnginePatches.cpp
+++ b/Game/EnginePatches.cpp
@@ -46,7 +46,7 @@ void SwapRgssadEncryption(const char* library_path) {
     scanner.Scan();
 
     // Only sig patch if we've found both the header and the key
-    if (scanner.HasFound("RGSSAD_Header") && scanner.HasFound("RGSSAD_Key")) {
+    if (scanner.HasFoundAll()) {
         auto header_address = scanner.GetScannedAddress("RGSSAD_Header");
         auto key_address = scanner.GetScannedAddress("RGSSAD_Key");
 

--- a/Game/EnginePatches.cpp
+++ b/Game/EnginePatches.cpp
@@ -1,0 +1,23 @@
+#include "AriMath.h"
+#include "EnginePatches.h"
+#include "RubyCommon.h"
+
+namespace Patches {
+
+// TODO(David): Custom Container loader
+/*
+using PrepareRGSSADType = bool (*)(LPCSTR lpFileName);
+using ReadRGSSADType = bool (*)(char* filename, char** file_buffer, int* size);
+using MallocType = void* (*)(unsigned int size);
+
+PrepareRGSSADType ORIGINAL_PREPARE_RGSSAD = nullptr;
+ReadRGSSADType ORIGINAL_READ_RGSSAD = nullptr;
+MallocType RGSSAD_MALLOC = nullptr;
+*/
+
+void SetupDetours(const char* library_path) {
+    Ruby::Common::Get()->AddNewModule(&RubyModule::RegisterAriMath);
+    Ruby::Common::Get()->Initialize(library_path);
+}
+
+} // namespace Patches

--- a/Game/EnginePatches.cpp
+++ b/Game/EnginePatches.cpp
@@ -1,6 +1,11 @@
+#include <array>
+#include <Windows.h>
 #include "AriMath.h"
+#include "Common.h"
 #include "EnginePatches.h"
+#include "MemoryUtil.h"
 #include "RubyCommon.h"
+#include "SigScanner.h"
 
 namespace Patches {
 
@@ -18,6 +23,69 @@ MallocType RGSSAD_MALLOC = nullptr;
 void SetupDetours(const char* library_path) {
     Ruby::Common::Get()->AddNewModule(&RubyModule::RegisterAriMath);
     Ruby::Common::Get()->Initialize(library_path);
+}
+
+/* Encryption key swap */
+constexpr std::array<char, 8> PATCHED_HEADER{'\x31', '\xac', '\x3e', '\x2d',
+                                             '\x9b', '\x23', '\xda', '\x11'};
+constexpr unsigned int NEW_KEY = 0xBCF33B95;
+void SwapRgssadEncryption(const char* library_path) {
+    MemoryUtil::SigScanner scanner(library_path);
+    // Locate the RGSSAD header to change the bytes to something else. The fields for the header are
+    // not actually meaningful and are just checked against a block of memory to make sure they
+    // match
+    scanner.AddNewSignature(
+        "RGSSAD_Header",
+        "\x52\x00\x00\x00\x47\x00\x00\x00\x53\x00\x00\x00\x53\x00\x00\x00\x41\x00\x00"
+        "\x00\x44\x00\x00\x00\x00\x00\x00\x00\x01",
+        "x???x???x???x???x???x???x???x");
+
+    // Locate the base RGSSAD encryption key
+    scanner.AddNewSignature("RGSSAD_Key", "\xFE\xCA\xAD\xDE", "xxxx");
+
+    scanner.Scan();
+
+    // Only sig patch if we've found both the header and the key
+    if (scanner.HasFound("RGSSAD_Header") && scanner.HasFound("RGSSAD_Key")) {
+        auto header_address = scanner.GetScannedAddress("RGSSAD_Header");
+        auto key_address = scanner.GetScannedAddress("RGSSAD_Key");
+
+        // Copy our new header bytes and write
+        std::array<char, 32> header;
+        std::memcpy(header.data(), reinterpret_cast<void*>(header_address), header.size());
+        for (std::size_t i = 0; i < PATCHED_HEADER.size(); i++) {
+            header[i * 4] = PATCHED_HEADER[i];
+        }
+
+        // Overwrite the header to the new header
+        MemoryUtil::PatchBytes(header_address, header.data(), header.size());
+
+        // Change the encryption key used for """decrypting""" RGSSADs
+        MemoryUtil::PatchType<unsigned int>(key_address, NEW_KEY);
+    } else {
+        LOG("Incorrect RGSSAD dll supplied!");
+    }
+}
+
+/* Allow debugger patch */
+// If we're running from a debugger or within MSVC, we'll get a debugger is attached error. We
+// patch out the IsDebuggerPresent() check just to allow the ability to debug
+void PatchDebugPresent() {
+    const auto kernel32 = GetModuleHandle("Kernel32.dll");
+    if (kernel32 == 0) {
+        return;
+    }
+    auto addr = GetProcAddress(kernel32, "IsDebuggerPresent");
+    if (addr == 0) {
+        return;
+    }
+
+    // EAX stores the return of IsDebuggerPresent()
+    std::array<char, 3> patch{
+        '\x31', '\xC0', // xor eax, eax
+        '\xC3'          // ret
+    };
+    MemoryUtil::PatchBytes(reinterpret_cast<DWORD>(addr), patch.data(), patch.size());
 }
 
 } // namespace Patches

--- a/Game/EnginePatches.h
+++ b/Game/EnginePatches.h
@@ -2,4 +2,6 @@
 
 namespace Patches {
 void SetupDetours(const char* library_path);
+void SwapRgssadEncryption(const char* library_path);
+void PatchDebugPresent();
 } // namespace Patches

--- a/Game/EnginePatches.h
+++ b/Game/EnginePatches.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace Patches {
+void SetupDetours(const char* library_path);
+} // namespace Patches

--- a/Game/FileIO.cpp
+++ b/Game/FileIO.cpp
@@ -1,0 +1,44 @@
+#include "FileIO.h"
+
+namespace IO {
+File::File(const char* filename, const char* mode) {
+    if (fopen_s(&fp, filename, mode)) {
+        return;
+    }
+    Seek(0, Origin::End);
+    file_size = Tell();
+    Seek(0, Origin::Set);
+}
+
+File::~File() {
+    if (fp) {
+        fclose(fp);
+    }
+}
+
+void File::Seek(std::size_t offset, File::Origin origin) {
+    if (!fp) {
+        return;
+    }
+    fseek(fp, offset, static_cast<int>(origin));
+}
+
+std::size_t File::Tell() {
+    if (!fp) {
+        return 0;
+    }
+    return ftell(fp);
+}
+
+std::size_t File::Size() const {
+    if (!fp) {
+        return 0;
+    }
+    return file_size;
+}
+
+bool File::Open() const {
+    return fp != nullptr;
+}
+
+} // namespace IO

--- a/Game/FileIO.h
+++ b/Game/FileIO.h
@@ -1,0 +1,83 @@
+#pragma once
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace IO {
+
+class File {
+public:
+    enum class Origin {
+        Set = SEEK_SET,
+        Cur = SEEK_CUR,
+        End = SEEK_END,
+    };
+
+    File(const char* filename, const char* mode);
+    ~File();
+
+    void Seek(std::size_t offset, File::Origin origin = File::Origin::Set);
+    std::size_t Tell();
+    std::size_t Size() const;
+    bool Open() const;
+
+    template <typename T>
+    std::size_t Write(T data, std::size_t count = 1) {
+        if (!fp) {
+            return 0;
+        }
+        return fwrite(&data, sizeof(T), count, fp);
+    }
+
+    template <>
+    std::size_t Write(std::string data, std::size_t count) {
+        if (!fp) {
+            return 0;
+        }
+        const std::size_t str_len = data.length();
+        fwrite(&str_len, sizeof(std::size_t), count, fp);
+        return fwrite(data.c_str(), 1, str_len, fp);
+    }
+
+    std::size_t WriteBuffer(const void* data, std::size_t size) {
+        if (!fp) {
+            return 0;
+        }
+        return fwrite(data, size, 1, fp);
+    }
+
+    void ReadBuffer(void* data, std::size_t size) {
+        if (!fp) {
+            return;
+        }
+        fread(data, size, 1, fp);
+    }
+
+    template <typename T>
+    T Read() {
+        T t{};
+        if (!fp) {
+            return t;
+        }
+        std::fread(&t, sizeof(T), 1, fp);
+        return t;
+    }
+
+    template <>
+    std::string Read() {
+        if (!fp) {
+            return {};
+        }
+        const std::size_t str_len = Read<std::size_t>();
+        std::string output{};
+        output.resize(str_len);
+        fread(output.data(), 1, str_len, fp);
+        return output;
+    }
+
+private:
+    std::size_t file_size{};
+    FILE* fp = nullptr;
+};
+
+} // namespace IO

--- a/Game/Game.vcxproj
+++ b/Game/Game.vcxproj
@@ -152,11 +152,10 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AriMath.h" />
+    <ClInclude Include="Common.h" />
     <ClInclude Include="EnginePatches.h" />
     <ClInclude Include="ld32.h" />
     <ClInclude Include="MemoryUtil.h" />
-    <ClInclude Include="resource.h" />
-    <ClInclude Include="resource1.h" />
     <ClInclude Include="RubyCommon.h" />
     <ClInclude Include="SigScanner.h" />
   </ItemGroup>

--- a/Game/Game.vcxproj
+++ b/Game/Game.vcxproj
@@ -142,12 +142,22 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="AriMath.cpp" />
+    <ClCompile Include="EnginePatches.cpp" />
+    <ClCompile Include="ld32.c" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MemoryUtil.cpp" />
+    <ClCompile Include="RubyCommon.cpp" />
     <ClCompile Include="SigScanner.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AriMath.h" />
+    <ClInclude Include="EnginePatches.h" />
+    <ClInclude Include="ld32.h" />
     <ClInclude Include="MemoryUtil.h" />
+    <ClInclude Include="resource.h" />
+    <ClInclude Include="resource1.h" />
+    <ClInclude Include="RubyCommon.h" />
     <ClInclude Include="SigScanner.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Game/Game.vcxproj
+++ b/Game/Game.vcxproj
@@ -144,6 +144,7 @@
   <ItemGroup>
     <ClCompile Include="AriMath.cpp" />
     <ClCompile Include="EnginePatches.cpp" />
+    <ClCompile Include="FileIO.cpp" />
     <ClCompile Include="ld32.c" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MemoryUtil.cpp" />
@@ -154,6 +155,7 @@
     <ClInclude Include="AriMath.h" />
     <ClInclude Include="Common.h" />
     <ClInclude Include="EnginePatches.h" />
+    <ClInclude Include="FileIO.h" />
     <ClInclude Include="ld32.h" />
     <ClInclude Include="MemoryUtil.h" />
     <ClInclude Include="RubyCommon.h" />

--- a/Game/Game.vcxproj.filters
+++ b/Game/Game.vcxproj.filters
@@ -9,9 +9,14 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    <Filter Include="Resources">
+      <UniqueIdentifier>{7d5054c0-7678-4937-872a-09d82a7efa96}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\RubyModules">
+      <UniqueIdentifier>{322bf567-4097-46fe-ac8d-b92adeacda54}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\RubyModules">
+      <UniqueIdentifier>{f769a3d0-a5fd-4895-8eb6-ec277df8939d}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -24,6 +29,18 @@
     <ClCompile Include="SigScanner.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ld32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="EnginePatches.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="AriMath.cpp">
+      <Filter>Source Files\RubyModules</Filter>
+    </ClCompile>
+    <ClCompile Include="RubyCommon.cpp">
+      <Filter>Source Files\RubyModules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SigScanner.h">
@@ -31,6 +48,24 @@
     </ClInclude>
     <ClInclude Include="MemoryUtil.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="resource1.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ld32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EnginePatches.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="AriMath.h">
+      <Filter>Header Files\RubyModules</Filter>
+    </ClInclude>
+    <ClInclude Include="RubyCommon.h">
+      <Filter>Header Files\RubyModules</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Game/Game.vcxproj.filters
+++ b/Game/Game.vcxproj.filters
@@ -49,12 +49,6 @@
     <ClInclude Include="MemoryUtil.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="resource.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="resource1.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="ld32.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -66,6 +60,9 @@
     </ClInclude>
     <ClInclude Include="RubyCommon.h">
       <Filter>Header Files\RubyModules</Filter>
+    </ClInclude>
+    <ClInclude Include="Common.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Game/Game.vcxproj.filters
+++ b/Game/Game.vcxproj.filters
@@ -41,6 +41,9 @@
     <ClCompile Include="RubyCommon.cpp">
       <Filter>Source Files\RubyModules</Filter>
     </ClCompile>
+    <ClCompile Include="FileIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SigScanner.h">
@@ -62,6 +65,9 @@
       <Filter>Header Files\RubyModules</Filter>
     </ClInclude>
     <ClInclude Include="Common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="FileIO.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Game/MemoryUtil.cpp
+++ b/Game/MemoryUtil.cpp
@@ -1,63 +1,48 @@
+#include <array>
 #include "MemoryUtil.h"
 
 namespace MemoryUtil {
 
-void NopSled(DWORD address, std::size_t length) {
-    DWORD memory_protection{};
-    VirtualProtect(reinterpret_cast<LPVOID>(address), length, PAGE_EXECUTE_READWRITE,
-                   &memory_protection);
+void NopSled(uintptr_t address, std::size_t length) {
+    ReprotectScope<MemPerm::ReadWriteExecute> protection(address, length);
 
     unsigned char* p = reinterpret_cast<unsigned char*>(address);
     // Fill memory with NOPs
     for (std::size_t i = 0; i < length; i++) {
         *(unsigned char*)(address + i) = 0x90; // The opcode 0x90 is NOP
     }
-
-    VirtualProtect(reinterpret_cast<LPVOID>(address), length, memory_protection,
-                   &memory_protection);
 }
 
-void PatchBytes(DWORD address, char* bytes, std::size_t length) {
-    DWORD memory_protection{};
-    VirtualProtect(reinterpret_cast<LPVOID>(address), length, PAGE_EXECUTE_READWRITE,
-                   &memory_protection);
-
+void PatchBytes(uintptr_t address, char* bytes, std::size_t length) {
+    ReprotectScope<MemPerm::ReadWriteExecute> protection(address, length);
     char* p = reinterpret_cast<char*>(address);
 
     // Overwrite memory region with our data
     for (std::size_t i = 0; i < length; i++) {
         *(p++) = *(bytes++);
     }
-
-    VirtualProtect(reinterpret_cast<LPVOID>(address), length, memory_protection,
-                   &memory_protection);
 }
 
-void PatchJump(DWORD src, DWORD dst) {
-    DWORD memory_protection{};
-    VirtualProtect(reinterpret_cast<LPVOID>(src), 5, PAGE_EXECUTE_READWRITE, &memory_protection);
+void PatchJump(uintptr_t src, uintptr_t dst) {
+    ReprotectScope<MemPerm::ReadWriteExecute> protection(src, INS_JMP_LENGTH);
 
     // Call our helper function which just writes a JMP
     PatchJumpNoProtect(src, dst);
-
-    VirtualProtect(reinterpret_cast<LPVOID>(src), 5, memory_protection, &memory_protection);
 }
 
-void PatchJumpNoProtect(DWORD src, DWORD dst) {
+void PatchJumpNoProtect(uintptr_t src, uintptr_t dst) {
     // JMP 0xAABBCCDD
-    *(unsigned char*)(src) = 0xe9;                      // JMP
-    *(DWORD*)(src + 1) = CalculateJumpOffset(src, dst); // Address offset to jump to
+    *(unsigned char*)(src) = 0xe9;                          // JMP
+    *(uintptr_t*)(src + 1) = CalculateJumpOffset(src, dst); // Address offset to jump to
 }
-DWORD CalculateJumpOffset(DWORD src, DWORD dst) {
+uintptr_t CalculateJumpOffset(uintptr_t src, uintptr_t dst) {
     // (Destination Address - Starting Address) - Size of jmp instruction
     return (dst - src) - 5;
 }
 
-DWORD CallToDirectAddress(DWORD src) {
-    DWORD address{};
-    DWORD memory_protection{};
-    VirtualProtect(reinterpret_cast<LPVOID>(src), MAX_INS_LENGTH, PAGE_EXECUTE_READWRITE,
-                   &memory_protection);
+uintptr_t CallToDirectAddress(uintptr_t src) {
+    ReprotectScope<MemPerm::ReadWriteExecute> protection(src, MAX_INS_LENGTH);
+    uintptr_t address{};
 
     const char ins = *(char*)(src);
     if (ins == '\xE8') {
@@ -67,9 +52,22 @@ DWORD CallToDirectAddress(DWORD src) {
         DebugBreak();
     }
 
-    VirtualProtect(reinterpret_cast<LPVOID>(src), MAX_INS_LENGTH, memory_protection,
-                   &memory_protection);
     return address;
+}
+
+uintptr_t SlideAddress(uintptr_t base, uintptr_t offset) {
+    return base + offset;
+}
+
+uintptr_t SlideAddress(uintptr_t base, uintptr_t old_base, uintptr_t address) {
+    return base + (address - old_base);
+}
+
+MemPerm Reprotect(uintptr_t address, std::size_t size, MemPerm new_permissions) {
+    DWORD memory_protection{};
+    VirtualProtect(reinterpret_cast<LPVOID>(address), size, static_cast<DWORD>(new_permissions),
+                   &memory_protection);
+    return static_cast<MemPerm>(memory_protection);
 }
 
 } // namespace MemoryUtil

--- a/Game/MemoryUtil.cpp
+++ b/Game/MemoryUtil.cpp
@@ -2,6 +2,21 @@
 
 namespace MemoryUtil {
 
+void NopSled(DWORD address, std::size_t length) {
+    DWORD memory_protection{};
+    VirtualProtect(reinterpret_cast<LPVOID>(address), length, PAGE_EXECUTE_READWRITE,
+                   &memory_protection);
+
+    unsigned char* p = reinterpret_cast<unsigned char*>(address);
+    // Fill memory with NOPs
+    for (std::size_t i = 0; i < length; i++) {
+        *(unsigned char*)(address + i) = 0x90; // The opcode 0x90 is NOP
+    }
+
+    VirtualProtect(reinterpret_cast<LPVOID>(address), length, memory_protection,
+                   &memory_protection);
+}
+
 void PatchBytes(DWORD address, char* bytes, std::size_t length) {
     DWORD memory_protection{};
     VirtualProtect(reinterpret_cast<LPVOID>(address), length, PAGE_EXECUTE_READWRITE,
@@ -22,16 +37,39 @@ void PatchJump(DWORD src, DWORD dst) {
     DWORD memory_protection{};
     VirtualProtect(reinterpret_cast<LPVOID>(src), 5, PAGE_EXECUTE_READWRITE, &memory_protection);
 
-    // JMP 0xAABBCCDD
-    *(char*)(src) = 0xe9;                               // JMP
-    *(DWORD*)(src + 1) = CalculateJumpOffset(src, dst); // Address offset to jump to
+    // Call our helper function which just writes a JMP
+    PatchJumpNoProtect(src, dst);
 
     VirtualProtect(reinterpret_cast<LPVOID>(src), 5, memory_protection, &memory_protection);
 }
 
+void PatchJumpNoProtect(DWORD src, DWORD dst) {
+    // JMP 0xAABBCCDD
+    *(unsigned char*)(src) = 0xe9;                      // JMP
+    *(DWORD*)(src + 1) = CalculateJumpOffset(src, dst); // Address offset to jump to
+}
 DWORD CalculateJumpOffset(DWORD src, DWORD dst) {
     // (Destination Address - Starting Address) - Size of jmp instruction
     return (dst - src) - 5;
+}
+
+DWORD CallToDirectAddress(DWORD src) {
+    DWORD address{};
+    DWORD memory_protection{};
+    VirtualProtect(reinterpret_cast<LPVOID>(src), MAX_INS_LENGTH, PAGE_EXECUTE_READWRITE,
+                   &memory_protection);
+
+    const char ins = *(char*)(src);
+    if (ins == '\xE8') {
+        // Base + Offset + instruction size
+        address = src + *(DWORD*)(src + 1) + 5;
+    } else {
+        DebugBreak();
+    }
+
+    VirtualProtect(reinterpret_cast<LPVOID>(src), MAX_INS_LENGTH, memory_protection,
+                   &memory_protection);
+    return address;
 }
 
 } // namespace MemoryUtil

--- a/Game/MemoryUtil.h
+++ b/Game/MemoryUtil.h
@@ -1,11 +1,21 @@
 #pragma once
 #include <cstring>
 #include <Windows.h>
+extern "C" {
+#include "ld32.h"
+}
 
 namespace MemoryUtil {
+constexpr std::size_t MAX_INS_LENGTH = 15;
+constexpr std::size_t INS_JMP_LENGTH = 5;
+
+void NopSled(DWORD address, std::size_t length);
 void PatchBytes(DWORD address, char* bytes, std::size_t length);
 void PatchJump(DWORD src, DWORD dst);
+void PatchJumpNoProtect(DWORD src, DWORD dst);
+void* CreateDetour(DWORD src, DWORD dst);
 DWORD CalculateJumpOffset(DWORD src, DWORD dst);
+DWORD CallToDirectAddress(DWORD src);
 
 template <typename T>
 void PatchType(DWORD address, T data) {
@@ -21,6 +31,57 @@ void PatchType(DWORD address, T data) {
     // Revert the memory regions permissions
     VirtualProtect(reinterpret_cast<LPVOID>(address), sizeof(T), memory_protection,
                    &memory_protection);
+}
+
+template <typename T>
+T MakeCallable(DWORD address) {
+    return reinterpret_cast<T>(address);
+}
+
+template <typename T>
+T CreateDetour(DWORD src, DWORD dst) {
+    DWORD memory_protection{};
+    DWORD memory_protection2{};
+
+    // Allow us to modify memory
+    VirtualProtect(reinterpret_cast<LPVOID>(src), MAX_INS_LENGTH, PAGE_EXECUTE_READWRITE,
+                   &memory_protection);
+
+    // Get at least 5 bytes of instructions
+    std::size_t total_to_copy = 0;
+    while (total_to_copy < INS_JMP_LENGTH) {
+        total_to_copy += length_disasm(reinterpret_cast<void*>(src + total_to_copy));
+    }
+
+    // Code cave for our bytes we copied + a jump instruction
+    void* og_func = malloc(total_to_copy + INS_JMP_LENGTH);
+    // FUNCTION_BLOCKS.push_back(og_func);
+
+    // Mark our region as Read Write Execute
+    VirtualProtect(reinterpret_cast<LPVOID>(og_func), total_to_copy + INS_JMP_LENGTH,
+                   PAGE_EXECUTE_READWRITE, &memory_protection2);
+
+    // Copy our bytes to our code caved section
+    std::memcpy(og_func, reinterpret_cast<void*>(src), total_to_copy);
+
+    // Jump to our original function and continue execution flow
+    PatchJumpNoProtect(reinterpret_cast<DWORD>(og_func) + total_to_copy, src + total_to_copy);
+
+    // Nop sled if we have more than 5 bytes copied to prevent creating bad instructions
+    const std::size_t ins_to_sled = total_to_copy - INS_JMP_LENGTH;
+    if (ins_to_sled > 0) {
+        NopSled(src + INS_JMP_LENGTH, ins_to_sled);
+    }
+
+    // Patch the base of the func to jump to our detour
+    PatchJumpNoProtect(src, dst);
+
+    // Reset permissions
+    VirtualProtect(reinterpret_cast<LPVOID>(src), MAX_INS_LENGTH, memory_protection,
+                   &memory_protection);
+
+    // Return our codecave which jumps to the original function
+    return static_cast<T>(og_func);
 }
 
 } // namespace MemoryUtil

--- a/Game/MemoryUtil.h
+++ b/Game/MemoryUtil.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstring>
+#include <type_traits>
 #include <Windows.h>
 extern "C" {
 #include "ld32.h"
@@ -36,6 +37,41 @@ void PatchType(DWORD address, T data) {
 template <typename T>
 T MakeCallable(DWORD address) {
     return reinterpret_cast<T>(address);
+}
+
+enum class CallConvention { CDecl, ClrCall, StdCall, FastCall, ThisCall, VectorCall };
+template <CallConvention C, typename T, typename... ARGS>
+struct BuildCallable {
+    constexpr static auto value() {
+        if constexpr (C == CallConvention::CDecl) {
+            return static_cast<T(_cdecl*)(ARGS...)>(nullptr);
+        } else if constexpr (C == CallConvention::ClrCall) {
+#ifndef __cplusplus_cli
+            static_assert(false, "Requires /clr or /ZW command line option");
+#else
+            return static_cast<T(__clrcall*)(ARGS...)>(nullptr);
+#endif
+        } else if constexpr (C == CallConvention::StdCall) {
+            return static_cast<T(__stdcall*)(ARGS...)>(nullptr);
+        } else if constexpr (C == CallConvention::FastCall) {
+            return static_cast<T(__fastcall*)(ARGS...)>(nullptr);
+        } else if constexpr (C == CallConvention::ThisCall) {
+            return static_cast<T(__thiscall*)(ARGS...)>(nullptr);
+        } else if constexpr (C == CallConvention::VectorCall) {
+            return static_cast<T(__vectorcall*)(ARGS...)>(nullptr);
+        } else {
+            static_assert(false, "Invalid call convention");
+        }
+    }
+};
+template <CallConvention C, typename R, typename... ARGS>
+R AddressCall(DWORD address, ARGS... args) {
+    using CALLABLE = decltype(BuildCallable<C, R, ARGS...>::value());
+    if constexpr (std::is_void_v<R>) {
+        reinterpret_cast<CALLABLE>(address)(args...);
+    } else {
+        return reinterpret_cast<CALLABLE>(address)(args...);
+    }
 }
 
 template <typename T>

--- a/Game/MemoryUtil.h
+++ b/Game/MemoryUtil.h
@@ -9,33 +9,54 @@ extern "C" {
 namespace MemoryUtil {
 constexpr std::size_t MAX_INS_LENGTH = 15;
 constexpr std::size_t INS_JMP_LENGTH = 5;
+enum class MemPerm : DWORD {
+    NoAccess = PAGE_NOACCESS,
+    Read = PAGE_READONLY,
+    Execute = PAGE_EXECUTE,
+    ReadWrite = PAGE_READWRITE,
+    ReadWriteExecute = PAGE_EXECUTE_READWRITE,
+    ReadExecute = PAGE_EXECUTE_READ,
+};
 
-void NopSled(DWORD address, std::size_t length);
-void PatchBytes(DWORD address, char* bytes, std::size_t length);
-void PatchJump(DWORD src, DWORD dst);
-void PatchJumpNoProtect(DWORD src, DWORD dst);
-void* CreateDetour(DWORD src, DWORD dst);
-DWORD CalculateJumpOffset(DWORD src, DWORD dst);
-DWORD CallToDirectAddress(DWORD src);
+void NopSled(uintptr_t address, std::size_t length);
+void PatchBytes(uintptr_t address, char* bytes, std::size_t length);
+void PatchJump(uintptr_t src, uintptr_t dst);
+void PatchJumpNoProtect(uintptr_t src, uintptr_t dst);
+void* CreateDetour(uintptr_t src, uintptr_t dst);
+uintptr_t CalculateJumpOffset(uintptr_t src, uintptr_t dst);
+uintptr_t CallToDirectAddress(uintptr_t src);
+uintptr_t SlideAddress(uintptr_t base, uintptr_t offset);
+uintptr_t SlideAddress(uintptr_t base, uintptr_t old_base, uintptr_t address);
+MemPerm Reprotect(uintptr_t address, std::size_t size, MemPerm new_permissions);
+
+template <MemPerm TARGET>
+class ReprotectScope {
+public:
+    ReprotectScope(uintptr_t address, std::size_t size) : address(address), size(size) {
+        last_protection = Reprotect(address, size, TARGET);
+    }
+    ~ReprotectScope() {
+        Reprotect(address, size, last_protection);
+    }
+
+private:
+    MemPerm last_protection{};
+    uintptr_t address{};
+    std::size_t size{};
+};
 
 template <typename T>
-void PatchType(DWORD address, T data) {
-    DWORD memory_protection{};
+void PatchType(uintptr_t address, T data) {
     // Allow us to read, write and execute the memory region we're modifying
-    VirtualProtect(reinterpret_cast<LPVOID>(address), sizeof(T), PAGE_EXECUTE_READWRITE,
-                   &memory_protection);
+    ReprotectScope<MemPerm::ReadWriteExecute> protection(address, sizeof(T));
 
     // Write to the region
     T* p = reinterpret_cast<T*>(address);
     *p = data;
-
-    // Revert the memory regions permissions
-    VirtualProtect(reinterpret_cast<LPVOID>(address), sizeof(T), memory_protection,
-                   &memory_protection);
 }
 
 template <typename T>
-T MakeCallable(DWORD address) {
+T MakeCallable(uintptr_t address) {
     return reinterpret_cast<T>(address);
 }
 
@@ -75,13 +96,9 @@ R AddressCall(DWORD address, ARGS... args) {
 }
 
 template <typename T>
-T CreateDetour(DWORD src, DWORD dst) {
-    DWORD memory_protection{};
-    DWORD memory_protection2{};
-
+T CreateDetour(uintptr_t src, uintptr_t dst) {
     // Allow us to modify memory
-    VirtualProtect(reinterpret_cast<LPVOID>(src), MAX_INS_LENGTH, PAGE_EXECUTE_READWRITE,
-                   &memory_protection);
+    ReprotectScope<MemPerm::ReadWriteExecute> protection_main(src, MAX_INS_LENGTH);
 
     // Get at least 5 bytes of instructions
     std::size_t total_to_copy = 0;
@@ -90,18 +107,17 @@ T CreateDetour(DWORD src, DWORD dst) {
     }
 
     // Code cave for our bytes we copied + a jump instruction
-    void* og_func = malloc(total_to_copy + INS_JMP_LENGTH);
+    uintptr_t og_func = reinterpret_cast<uintptr_t>(malloc(total_to_copy + INS_JMP_LENGTH));
     // FUNCTION_BLOCKS.push_back(og_func);
 
     // Mark our region as Read Write Execute
-    VirtualProtect(reinterpret_cast<LPVOID>(og_func), total_to_copy + INS_JMP_LENGTH,
-                   PAGE_EXECUTE_READWRITE, &memory_protection2);
+    Reprotect(og_func, total_to_copy + INS_JMP_LENGTH, MemPerm::ReadWriteExecute);
 
     // Copy our bytes to our code caved section
-    std::memcpy(og_func, reinterpret_cast<void*>(src), total_to_copy);
+    std::memcpy(reinterpret_cast<void*>(og_func), reinterpret_cast<void*>(src), total_to_copy);
 
     // Jump to our original function and continue execution flow
-    PatchJumpNoProtect(reinterpret_cast<DWORD>(og_func) + total_to_copy, src + total_to_copy);
+    PatchJumpNoProtect(og_func + total_to_copy, src + total_to_copy);
 
     // Nop sled if we have more than 5 bytes copied to prevent creating bad instructions
     const std::size_t ins_to_sled = total_to_copy - INS_JMP_LENGTH;
@@ -112,12 +128,8 @@ T CreateDetour(DWORD src, DWORD dst) {
     // Patch the base of the func to jump to our detour
     PatchJumpNoProtect(src, dst);
 
-    // Reset permissions
-    VirtualProtect(reinterpret_cast<LPVOID>(src), MAX_INS_LENGTH, memory_protection,
-                   &memory_protection);
-
     // Return our codecave which jumps to the original function
-    return static_cast<T>(og_func);
+    return reinterpret_cast<T>(og_func);
 }
 
 } // namespace MemoryUtil

--- a/Game/MemoryUtil.h
+++ b/Game/MemoryUtil.h
@@ -59,8 +59,8 @@ void PatchType(uintptr_t address, T data) {
     *p = data;
 }
 
-template <typename T>
-T MakeCallable(uintptr_t address) {
+template <typename T, typename U>
+T MakeCallable(U address) {
     return reinterpret_cast<T>(address);
 }
 

--- a/Game/MemoryUtil.h
+++ b/Game/MemoryUtil.h
@@ -22,7 +22,6 @@ void NopSled(uintptr_t address, std::size_t length);
 void PatchBytes(uintptr_t address, const char* bytes, std::size_t length);
 void PatchJump(uintptr_t src, uintptr_t dst);
 void PatchJumpNoProtect(uintptr_t src, uintptr_t dst);
-void* CreateDetour(uintptr_t src, uintptr_t dst);
 uintptr_t CalculateJumpOffset(uintptr_t src, uintptr_t dst);
 uintptr_t CallToDirectAddress(uintptr_t src);
 uintptr_t SlideAddress(uintptr_t base, uintptr_t offset);

--- a/Game/RubyCommon.cpp
+++ b/Game/RubyCommon.cpp
@@ -1,0 +1,102 @@
+#include "MemoryUtil.h"
+#include "RubyCommon.h"
+#include "SigScanner.h"
+
+namespace Ruby {
+Ruby::Common* Ruby::Common::instance = nullptr;
+Common::Common() = default;
+
+Ruby::Common* Common::Get() {
+    if (!instance) {
+        instance = new Ruby::Common();
+    }
+    return instance;
+}
+
+void Common::Initialize(const char* library_path) {
+    MemoryUtil::SigScanner scanner(library_path);
+    scanner.AddNewSignature("RegisterRectModule",
+                            "\xE8\x00\x00\x00\x00\xE8\x00\x00\x00\x00\x5D\xC3\xCC\xCC\xCC\x55",
+                            "x????x????xxxxxx");
+
+    scanner.AddNewSignature("rb_define_module",
+                            "\xE8\x00\x00\x00\x00\x83\xC4\x04\x89\x45\xF8\x8D\x45\x0C",
+                            "x????xxxxxxxxx");
+
+    scanner.AddNewSignature("rb_define_module_function", "\xE8\x00\x00\x00\x00\x83\xC4\x10\x6A\x09",
+                            "x????xxxxx");
+
+    scanner.AddNewSignature("rb_define_const", "\xE8\x00\x00\x00\x00\x83\xC4\x0C\x6A\x08",
+                            "x????xxxxx");
+
+    scanner.AddNewSignature("rb_float_new", "\xE8\x00\x00\x00\x00\x83\xC4\x08\xEB\x54",
+                            "x????xxxxx");
+    scanner.AddNewSignature("rb_float", "\x55\x8B\xEC\x83\xEC\x10\x8B\x45\xF8", "xxxxxxxxx");
+    scanner.Scan();
+
+    if (scanner.HasFoundAll()) {
+        const auto register_rect_module_addr =
+            MemoryUtil::CallToDirectAddress(scanner.GetScannedAddress("RegisterRectModule"));
+        const auto rb_define_module_addr =
+            MemoryUtil::CallToDirectAddress(scanner.GetScannedAddress("rb_define_module"));
+        const auto rb_define_module_function_addr =
+            MemoryUtil::CallToDirectAddress(scanner.GetScannedAddress("rb_define_module_function"));
+        const auto rb_define_const_addr =
+            MemoryUtil::CallToDirectAddress(scanner.GetScannedAddress("rb_define_const"));
+        const auto rb_float_new_addr =
+            MemoryUtil::CallToDirectAddress(scanner.GetScannedAddress("rb_float_new"));
+        const auto rb_float_addr = scanner.GetScannedAddress("rb_float");
+
+        O_RegisterRectModule = MemoryUtil::CreateDetour<RegisterRectModuleType>(
+            register_rect_module_addr, reinterpret_cast<DWORD>(&Common::RegisterRectModule));
+
+        rb_define_module = MemoryUtil::MakeCallable<RbDefineModuleType>(rb_define_module_addr);
+        rb_define_module_function =
+            MemoryUtil::MakeCallable<RbDefineModuleFunctionType>(rb_define_module_function_addr);
+        rb_define_const = MemoryUtil::MakeCallable<RbDefineConstType>(rb_define_const_addr);
+        rb_float_new = MemoryUtil::MakeCallable<RbFloatNewType>(rb_float_new_addr);
+        rb_float = MemoryUtil::MakeCallable<RbFloatType>(rb_float_addr);
+    }
+}
+
+void Common::AddNewModule(std::function<void()> f) {
+    module_registry.push_back(f);
+}
+
+VALUE Common::DefineModule(const char* module_name) {
+    return rb_define_module(module_name);
+}
+
+void Common::DefineModuleFunction(VALUE module_id, const char* method_name, void* method,
+                                  int argc) {
+    rb_define_module_function(module_id, method_name, method, argc);
+}
+
+void Common::DefineConst(VALUE module_id, const char* const_name, VALUE value) {
+    rb_define_const(module_id, const_name, value);
+}
+
+VALUE Common::MakeFloat(double value) {
+    return rb_float_new(value);
+}
+
+Ruby::Float* Common::GetFloat(VALUE value) {
+    return rb_float(value);
+}
+
+std::vector<std::function<void()>>& Common::GetModuleRegistry() {
+    return module_registry;
+}
+
+void Common::RegisterRectModule() {
+    Common::Get()->InternalRectCallback();
+    for (auto f : Common::Get()->GetModuleRegistry()) {
+        f();
+    }
+}
+
+void Common::InternalRectCallback() {
+    O_RegisterRectModule();
+}
+
+} // namespace Ruby

--- a/Game/RubyCommon.cpp
+++ b/Game/RubyCommon.cpp
@@ -53,6 +53,7 @@ void Common::Initialize(const char* library_path) {
         rb_define_module = MemoryUtil::MakeCallable<RbDefineModuleType>(rb_define_module_addr);
         rb_define_module_function =
             MemoryUtil::MakeCallable<RbDefineModuleFunctionType>(rb_define_module_function_addr);
+        rb_define_module_function_addr_abs = rb_define_module_addr;
         rb_define_const = MemoryUtil::MakeCallable<RbDefineConstType>(rb_define_const_addr);
         rb_float_new = MemoryUtil::MakeCallable<RbFloatNewType>(rb_float_new_addr);
         rb_float = MemoryUtil::MakeCallable<RbFloatType>(rb_float_addr);
@@ -63,24 +64,24 @@ void Common::AddNewModule(std::function<void()> f) {
     module_registry.push_back(f);
 }
 
-VALUE Common::DefineModule(const char* module_name) {
+RB_VALUE Common::DefineModule(const char* module_name) {
     return rb_define_module(module_name);
 }
 
-void Common::DefineModuleFunction(VALUE module_id, const char* method_name, void* method,
+void Common::DefineModuleFunction(RB_VALUE module_id, const char* method_name, void* method,
                                   int argc) {
     rb_define_module_function(module_id, method_name, method, argc);
 }
 
-void Common::DefineConst(VALUE module_id, const char* const_name, VALUE value) {
+void Common::DefineConst(RB_VALUE module_id, const char* const_name, RB_VALUE value) {
     rb_define_const(module_id, const_name, value);
 }
 
-VALUE Common::MakeFloat(double value) {
+RB_VALUE Common::MakeFloat(double value) {
     return rb_float_new(value);
 }
 
-Ruby::Float* Common::GetFloat(VALUE value) {
+Ruby::Float* Common::GetFloat(RB_VALUE value) {
     return rb_float(value);
 }
 

--- a/Game/RubyCommon.cpp
+++ b/Game/RubyCommon.cpp
@@ -48,12 +48,11 @@ void Common::Initialize(const char* library_path) {
         const auto rb_float_addr = scanner.GetScannedAddress("rb_float");
 
         O_RegisterRectModule = MemoryUtil::CreateDetour<RegisterRectModuleType>(
-            register_rect_module_addr, reinterpret_cast<DWORD>(&Common::RegisterRectModule));
+            register_rect_module_addr, reinterpret_cast<uintptr_t>(&Common::RegisterRectModule));
 
         rb_define_module = MemoryUtil::MakeCallable<RbDefineModuleType>(rb_define_module_addr);
         rb_define_module_function =
             MemoryUtil::MakeCallable<RbDefineModuleFunctionType>(rb_define_module_function_addr);
-        rb_define_module_function_addr_abs = rb_define_module_addr;
         rb_define_const = MemoryUtil::MakeCallable<RbDefineConstType>(rb_define_const_addr);
         rb_float_new = MemoryUtil::MakeCallable<RbFloatNewType>(rb_float_new_addr);
         rb_float = MemoryUtil::MakeCallable<RbFloatType>(rb_float_addr);

--- a/Game/RubyCommon.h
+++ b/Game/RubyCommon.h
@@ -30,8 +30,6 @@ public:
     static void RegisterRectModule();
     void InternalRectCallback();
 
-    DWORD rb_define_module_function_addr_abs{};
-
 private:
     static Ruby::Common* instance;
     Common();
@@ -44,12 +42,12 @@ private:
     using RbFloatNewType = RB_VALUE(__cdecl*)(double value);
     using RbFloatType = Ruby::Float*(__cdecl*)(RB_VALUE value);
 
-    RegisterRectModuleType O_RegisterRectModule;
-    RbDefineModuleType rb_define_module;
-    RbDefineModuleFunctionType rb_define_module_function;
-    RbDefineConstType rb_define_const;
-    RbFloatNewType rb_float_new;
-    RbFloatType rb_float;
+    RegisterRectModuleType O_RegisterRectModule{};
+    RbDefineModuleType rb_define_module{};
+    RbDefineModuleFunctionType rb_define_module_function{};
+    RbDefineConstType rb_define_const{};
+    RbFloatNewType rb_float_new{};
+    RbFloatType rb_float{};
 
     std::vector<std::function<void()>> module_registry;
 };

--- a/Game/RubyCommon.h
+++ b/Game/RubyCommon.h
@@ -21,10 +21,13 @@ public:
     void AddNewModule(std::function<void()> f);
 
     RB_VALUE DefineModule(const char* module_name);
+    RB_VALUE DefineClass(const char* name, RB_VALUE super);
     void DefineModuleFunction(RB_VALUE module_id, const char* method_name, void* method, int argc);
     void DefineConst(RB_VALUE module_id, const char* const_name, RB_VALUE value);
     RB_VALUE MakeFloat(double value);
     Ruby::Float* GetFloat(RB_VALUE value);
+    bool ObjIsInstanceOf(RB_VALUE obj, RB_VALUE c);
+    RB_VALUE GetcObject() const;
 
     std::vector<std::function<void()>>& GetModuleRegistry();
     static void RegisterRectModule();
@@ -41,6 +44,8 @@ private:
     using RbDefineConstType = void(__cdecl*)(RB_VALUE module_id, const char* name, RB_VALUE value);
     using RbFloatNewType = RB_VALUE(__cdecl*)(double value);
     using RbFloatType = Ruby::Float*(__cdecl*)(RB_VALUE value);
+    using RbObjIsInstanceOf = RB_VALUE(__cdecl*)(RB_VALUE obj, RB_VALUE c);
+    using RbDefineClass = RB_VALUE(__cdecl*)(const char* name, RB_VALUE super);
 
     RegisterRectModuleType O_RegisterRectModule{};
     RbDefineModuleType rb_define_module{};
@@ -48,6 +53,9 @@ private:
     RbDefineConstType rb_define_const{};
     RbFloatNewType rb_float_new{};
     RbFloatType rb_float{};
+    RbObjIsInstanceOf rb_obj_is_instance_of{};
+    RbDefineClass rb_define_class{};
+    RB_VALUE rb_cObject{};
 
     std::vector<std::function<void()>> module_registry;
 };

--- a/Game/RubyCommon.h
+++ b/Game/RubyCommon.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <functional>
+#include <vector>
+using VALUE = unsigned long;
+
+namespace Ruby {
+struct Float {
+    double GetValue() const {
+        return value;
+    }
+    int unknown0x0{};
+    double value{};
+};
+
+class Common {
+public:
+    static Ruby::Common* Get();
+
+    void Initialize(const char* library_path);
+    void AddNewModule(std::function<void()> f);
+
+    VALUE DefineModule(const char* module_name);
+    void DefineModuleFunction(VALUE module_id, const char* method_name, void* method, int argc);
+    void DefineConst(VALUE module_id, const char* const_name, VALUE value);
+    VALUE MakeFloat(double value);
+    Ruby::Float* GetFloat(VALUE value);
+
+    std::vector<std::function<void()>>& GetModuleRegistry();
+    static void RegisterRectModule();
+    void InternalRectCallback();
+
+private:
+    static Ruby::Common* instance;
+    Common();
+
+    using RegisterRectModuleType = void (*)();
+    using RbDefineModuleType = VALUE(__cdecl*)(const char* module_name);
+    using RbDefineModuleFunctionType = void(__cdecl*)(VALUE module_id, const char* method_name,
+                                                      void* method, int argument_count);
+    using RbDefineConstType = void(__cdecl*)(VALUE module_id, const char* name, VALUE value);
+    using RbFloatNewType = VALUE(__cdecl*)(double value);
+    using RbFloatType = Ruby::Float*(__cdecl*)(VALUE value);
+
+    RegisterRectModuleType O_RegisterRectModule;
+    RbDefineModuleType rb_define_module;
+    RbDefineModuleFunctionType rb_define_module_function;
+    RbDefineConstType rb_define_const;
+    RbFloatNewType rb_float_new;
+    RbFloatType rb_float;
+
+    std::vector<std::function<void()>> module_registry;
+};
+} // namespace Ruby

--- a/Game/RubyCommon.h
+++ b/Game/RubyCommon.h
@@ -1,7 +1,8 @@
 #pragma once
 #include <functional>
 #include <vector>
-using VALUE = unsigned long;
+#include <Windows.h>
+using RB_VALUE = unsigned long;
 
 namespace Ruby {
 struct Float {
@@ -19,27 +20,29 @@ public:
     void Initialize(const char* library_path);
     void AddNewModule(std::function<void()> f);
 
-    VALUE DefineModule(const char* module_name);
-    void DefineModuleFunction(VALUE module_id, const char* method_name, void* method, int argc);
-    void DefineConst(VALUE module_id, const char* const_name, VALUE value);
-    VALUE MakeFloat(double value);
-    Ruby::Float* GetFloat(VALUE value);
+    RB_VALUE DefineModule(const char* module_name);
+    void DefineModuleFunction(RB_VALUE module_id, const char* method_name, void* method, int argc);
+    void DefineConst(RB_VALUE module_id, const char* const_name, RB_VALUE value);
+    RB_VALUE MakeFloat(double value);
+    Ruby::Float* GetFloat(RB_VALUE value);
 
     std::vector<std::function<void()>>& GetModuleRegistry();
     static void RegisterRectModule();
     void InternalRectCallback();
+
+    DWORD rb_define_module_function_addr_abs{};
 
 private:
     static Ruby::Common* instance;
     Common();
 
     using RegisterRectModuleType = void (*)();
-    using RbDefineModuleType = VALUE(__cdecl*)(const char* module_name);
-    using RbDefineModuleFunctionType = void(__cdecl*)(VALUE module_id, const char* method_name,
+    using RbDefineModuleType = RB_VALUE(__cdecl*)(const char* module_name);
+    using RbDefineModuleFunctionType = void(__cdecl*)(RB_VALUE module_id, const char* method_name,
                                                       void* method, int argument_count);
-    using RbDefineConstType = void(__cdecl*)(VALUE module_id, const char* name, VALUE value);
-    using RbFloatNewType = VALUE(__cdecl*)(double value);
-    using RbFloatType = Ruby::Float*(__cdecl*)(VALUE value);
+    using RbDefineConstType = void(__cdecl*)(RB_VALUE module_id, const char* name, RB_VALUE value);
+    using RbFloatNewType = RB_VALUE(__cdecl*)(double value);
+    using RbFloatType = Ruby::Float*(__cdecl*)(RB_VALUE value);
 
     RegisterRectModuleType O_RegisterRectModule;
     RbDefineModuleType rb_define_module;

--- a/Game/SigScanner.cpp
+++ b/Game/SigScanner.cpp
@@ -57,7 +57,6 @@ void SigScanner::Scan() {
                     }
 
                     if (is_still_valid) {
-                        // TODO(David M): Validate signature to see if it's still valid
                         found_sigs[cache_sig.signature.name].address =
                             reinterpret_cast<uintptr_t>(base) + cache_sig.offset_from_base;
                         found_sigs[cache_sig.signature.name].signature = cache_sig.signature;

--- a/Game/SigScanner.cpp
+++ b/Game/SigScanner.cpp
@@ -23,8 +23,8 @@ void SigScanner::Scan() {
         return;
     }
 
-    char* p = (char*)base;
-    char* end = (char*)(p + module_info.SizeOfImage);
+    char* p = reinterpret_cast<char*>(base);
+    char* end = reinterpret_cast<char*>(p + module_info.SizeOfImage);
 
     // While we're not at the end of our image and we still need to look for signatures
     while (p < end && !sigs_to_find.empty()) {
@@ -45,7 +45,7 @@ void SigScanner::Scan() {
             }
             // If we scanned our whole signature without failing, we found our signature
             if (found) {
-                found_sigs[it->name] = (DWORD)p + it->offset;
+                found_sigs[it->name] = reinterpret_cast<uintptr_t>(p) + it->offset;
                 it = sigs_to_find.erase(it);
             } else {
                 it++;
@@ -67,7 +67,7 @@ void SigScanner::Reset() {
     sigs_to_find.clear();
 }
 
-std::optional<DWORD> SigScanner::GetScannedAddressOpt(std::string name) {
+std::optional<uintptr_t> SigScanner::GetScannedAddressOpt(std::string name) {
     // Check if the signature name exists
     auto it = found_sigs.find(name);
     if (it == found_sigs.end()) {
@@ -82,13 +82,13 @@ std::optional<DWORD> SigScanner::GetScannedAddressOpt(std::string name) {
     return it->second;
 }
 
-DWORD SigScanner::GetScannedAddress(std::string name) {
-    return GetScannedAddressOpt(name).value_or(0);
+uintptr_t SigScanner::GetScannedAddress(std::string_view name) {
+    return GetScannedAddressOpt(name.data()).value_or(0);
 }
 
-bool SigScanner::HasFound(std::string name) {
+bool SigScanner::HasFound(std::string_view name) {
     // Check if our address has a non zero value
-    return GetScannedAddressOpt(name).has_value();
+    return GetScannedAddressOpt(name.data()).has_value();
 }
 
 bool SigScanner::HasFoundAll() const {

--- a/Game/SigScanner.cpp
+++ b/Game/SigScanner.cpp
@@ -1,14 +1,19 @@
+#include <array>
+#include <vector>
 #include <Windows.h>
 #include <psapi.h>
+#include "FileIO.h"
 #include "SigScanner.h"
 
 namespace MemoryUtil {
 SigScanner::SigScanner(const char* mod) : module_to_scan(mod) {}
 SigScanner::~SigScanner() = default;
 
-void SigScanner::AddNewSignature(const char* _name, const char* _signature, const char* _mask,
+void SigScanner::AddNewSignature(const char* _name, const char* _signature, std::string _mask,
                                  std::size_t _offset) {
-    sigs_to_find.push_back(Signature{_name, _signature, _mask, _offset});
+    std::vector<char> signature_bytes(_mask.length());
+    std::memcpy(signature_bytes.data(), _signature, signature_bytes.size());
+    sigs_to_find.push_back(Signature{_name, signature_bytes, _mask, _offset});
 }
 
 void SigScanner::Scan() {
@@ -25,6 +30,28 @@ void SigScanner::Scan() {
 
     char* p = reinterpret_cast<char*>(base);
     char* end = reinterpret_cast<char*>(p + module_info.SizeOfImage);
+
+    auto cache = ReadFromCache();
+    for (auto& cache_module : cache) {
+        if (cache_module.module_name != module_to_scan) {
+            continue;
+        }
+        for (auto it = sigs_to_find.begin(); it != sigs_to_find.end();) {
+            for (auto& cache_sig : cache_module.signatures) {
+                if (cache_sig.signature != *it) {
+                    continue;
+                }
+                if (cache_sig.found) {
+                    // TODO(David M): Validate signature to see if it's still valid
+                    found_sigs[cache_sig.signature.name].address =
+                        reinterpret_cast<uintptr_t>(base) + cache_sig.offset_from_base;
+                    found_sigs[cache_sig.signature.name].signature = cache_sig.signature;
+                    it = sigs_to_find.erase(it);
+                    break;
+                }
+            }
+        }
+    }
 
     // While we're not at the end of our image and we still need to look for signatures
     while (p < end && !sigs_to_find.empty()) {
@@ -45,7 +72,8 @@ void SigScanner::Scan() {
             }
             // If we scanned our whole signature without failing, we found our signature
             if (found) {
-                found_sigs[it->name] = reinterpret_cast<uintptr_t>(p) + it->offset;
+                found_sigs[it->name].signature = *it;
+                found_sigs[it->name].address = reinterpret_cast<uintptr_t>(p) + it->offset;
                 it = sigs_to_find.erase(it);
             } else {
                 it++;
@@ -56,9 +84,12 @@ void SigScanner::Scan() {
 
     // Any remaining signatures should considered not found and have a
     for (auto& sig : sigs_to_find) {
-        found_sigs[sig.name] = 0; // An address of 0 is considered invalid
+        found_sigs[sig.name].address = 0; // An address of 0 is considered invalid
+        found_sigs[sig.name].signature = sig;
     }
     sigs_to_find.clear();
+
+    SaveResultToCache(reinterpret_cast<uintptr_t>(base));
 }
 
 void SigScanner::Reset() {
@@ -74,12 +105,12 @@ std::optional<uintptr_t> SigScanner::GetScannedAddressOpt(std::string name) {
         return {};
     }
     // If we have a zero address, assume it's invalid
-    if (it->second == 0) {
+    if (it->second.address == 0) {
         return {};
     }
 
     // Return the found address
-    return it->second;
+    return it->second.address;
 }
 
 uintptr_t SigScanner::GetScannedAddress(std::string_view name) {
@@ -95,12 +126,181 @@ bool SigScanner::HasFoundAll() const {
     // Check every signature
     for (const auto sig : found_sigs) {
         // If our signature failed to be found, bail
-        if (sig.second == 0) {
+        if (sig.second.address == 0) {
             return false;
         }
     }
     // All sigs are found
     return true;
+}
+
+// Magic header for cache container
+static constexpr std::array<char, 4> MAGIC = {'C', 'C', 'H', 'E'};
+
+void SigScanner::SaveResultToCache(uintptr_t base) {
+    // Get the current cache result
+    auto saved_cache = ReadFromCache();
+    bool is_module_in_cache = false;
+
+    // Check our cache
+    for (auto& cache_module : saved_cache) {
+        // Only update our current scanned module
+        if (cache_module.module_name != module_to_scan) {
+            continue;
+        }
+        is_module_in_cache = true;
+
+        // Check all our signatures after the scan
+        for (auto& sig : found_sigs) {
+            bool found = false;
+            // Check our cache
+            for (auto& cache_sig : cache_module.signatures) {
+
+                // Find the matching signature
+                if (cache_sig.signature == sig.second.signature) {
+                    found = true;
+                    // Check if it's a valid signature or needs to be updated
+                    if ((cache_sig.offset_from_base != (sig.second.address - base) &&
+                         sig.second.address != 0) ||
+                        (!cache_sig.found && sig.second.address != 0)) {
+                        // Update our signature
+                        cache_sig.found = true;
+                        cache_sig.offset_from_base = sig.second.address - base;
+                    }
+                    break;
+                }
+            }
+
+            // If the signature doesn't exist, add it
+            if (!found) {
+                CacheSignature cache_signature{};
+                cache_signature.signature = sig.second.signature;
+                cache_signature.found = sig.second.address != 0;
+                cache_signature.offset_from_base = sig.second.address - base;
+                cache_module.signatures.push_back(cache_signature);
+            }
+        }
+    }
+
+    // If our module doesn't exist, add it to the cache and our signatures
+    if (!is_module_in_cache) {
+        SigScanner::CacheModule cache_module{};
+        cache_module.module_name = module_to_scan;
+        for (auto& sig : found_sigs) {
+            SigScanner::CacheSignature cache_signature{};
+            cache_signature.found = sig.second.address != 0;
+            if (cache_signature.found) {
+                cache_signature.offset_from_base = sig.second.address - base;
+            }
+            cache_signature.signature = sig.second.signature;
+            cache_module.signatures.push_back(cache_signature);
+        }
+        saved_cache.push_back(cache_module);
+    }
+
+    // Cache saving
+    IO::File fp{"signatures.cache", "wb"};
+    if (!fp.Open()) {
+        return;
+    }
+
+    // Magic
+    fp.WriteBuffer(MAGIC.data(), 4);
+
+    // Module Count
+    fp.Write<std::size_t>(saved_cache.size());
+
+    for (const auto& cache_module : saved_cache) {
+        // Module Name
+        fp.Write(cache_module.module_name);
+
+        // Signature count
+        std::size_t signature_count{};
+        for (const auto& signature : cache_module.signatures) {
+            if (signature.found) {
+                signature_count++;
+            }
+        }
+        fp.Write<std::size_t>(signature_count);
+
+        for (const auto& signature : cache_module.signatures) {
+            if (!signature.found) {
+                continue;
+            }
+
+            const auto& sig = signature.signature;
+            // Signature name
+            fp.Write(sig.name);
+
+            // Signature Length
+            fp.Write<std::size_t>(sig.sig_length);
+
+            // Signature
+            fp.WriteBuffer(sig.signature.data(), sig.sig_length);
+
+            // Mask
+            fp.WriteBuffer(sig.mask.data(), sig.sig_length);
+
+            // Module Offset
+            fp.Write<std::size_t>(sig.offset);
+
+            // Offset from base
+            fp.Write<uintptr_t>(signature.offset_from_base);
+        }
+    }
+}
+
+std::vector<SigScanner::CacheModule> SigScanner::ReadFromCache() {
+    std::vector<SigScanner::CacheModule> cache{};
+    IO::File fp{"signatures.cache", "rb"};
+    if (!fp.Open()) {
+        return cache;
+    }
+
+    // Read magic
+    std::vector<char> magic(4);
+    fp.ReadBuffer(magic.data(), 4);
+    if (memcmp(MAGIC.data(), magic.data(), 4) != 0) {
+        return cache;
+    }
+
+    // Loop all modules
+    const auto module_count = fp.Read<std::size_t>();
+    for (std::size_t i = 0; i < module_count; i++) {
+        const auto module_name = fp.Read<std::string>();
+        const auto signature_count = fp.Read<std::size_t>();
+
+        SigScanner::CacheModule cache_module{};
+        cache_module.module_name = module_name;
+        // Loop all signatures for module
+        for (std::size_t j = 0; j < signature_count; j++) {
+            const auto signature_name = fp.Read<std::string>();
+            const auto signature_length = fp.Read<std::size_t>();
+            std::vector<char> signature(signature_length);
+            std::vector<char> mask(signature_length);
+
+            fp.ReadBuffer(signature.data(), signature.size());
+            fp.ReadBuffer(mask.data(), mask.size());
+
+            const auto signature_offset = fp.Read<std::size_t>();
+            const auto signature_offset_from_base = fp.Read<std::size_t>();
+
+            SigScanner::CacheSignature cache_signatures{};
+            cache_signatures.found = true;
+            cache_signatures.offset_from_base = signature_offset_from_base;
+
+            cache_signatures.signature.name = signature_name;
+            cache_signatures.signature.mask = std::string(mask.data());
+            cache_signatures.signature.signature = signature;
+
+            cache_signatures.signature.sig_length = signature_length;
+            cache_signatures.signature.offset = signature_offset;
+
+            cache_module.signatures.push_back(cache_signatures);
+        }
+        cache.push_back(cache_module);
+    }
+    return cache;
 }
 
 } // namespace MemoryUtil

--- a/Game/SigScanner.cpp
+++ b/Game/SigScanner.cpp
@@ -61,19 +61,46 @@ void SigScanner::Scan() {
     sigs_to_find.clear();
 }
 
-std::optional<DWORD> SigScanner::GetScannedAddress(std::string name) {
+void SigScanner::Reset() {
+    // Clear any sigs we need to find and the sigs we already found
+    found_sigs.clear();
+    sigs_to_find.clear();
+}
+
+std::optional<DWORD> SigScanner::GetScannedAddressOpt(std::string name) {
+    // Check if the signature name exists
     auto it = found_sigs.find(name);
     if (it == found_sigs.end()) {
         return {};
     }
+    // If we have a zero address, assume it's invalid
     if (it->second == 0) {
         return {};
     }
+
+    // Return the found address
     return it->second;
 }
 
+DWORD SigScanner::GetScannedAddress(std::string name) {
+    return GetScannedAddressOpt(name).value_or(0);
+}
+
 bool SigScanner::HasFound(std::string name) {
-    return GetScannedAddress(name).has_value();
+    // Check if our address has a non zero value
+    return GetScannedAddressOpt(name).has_value();
+}
+
+bool SigScanner::HasFoundAll() const {
+    // Check every signature
+    for (const auto sig : found_sigs) {
+        // If our signature failed to be found, bail
+        if (sig.second == 0) {
+            return false;
+        }
+    }
+    // All sigs are found
+    return true;
 }
 
 } // namespace MemoryUtil

--- a/Game/SigScanner.cpp
+++ b/Game/SigScanner.cpp
@@ -34,6 +34,7 @@ void SigScanner::Scan() {
             continue;
         }
         for (auto it = sigs_to_find.begin(); it != sigs_to_find.end();) {
+            bool is_in_cache = false;
             for (auto& cache_sig : cache_module.signatures) {
                 if (cache_sig.signature != *it) {
                     continue;
@@ -61,9 +62,13 @@ void SigScanner::Scan() {
                             reinterpret_cast<uintptr_t>(base) + cache_sig.offset_from_base;
                         found_sigs[cache_sig.signature.name].signature = cache_sig.signature;
                         it = sigs_to_find.erase(it);
+                        is_in_cache = true;
                     }
                     break;
                 }
+            }
+            if (!is_in_cache) {
+                it++;
             }
         }
     }

--- a/Game/SigScanner.h
+++ b/Game/SigScanner.h
@@ -17,9 +17,11 @@ public:
                          std::size_t _offset = 0);
 
     void Scan();
+    void Reset();
 
-    std::optional<DWORD> GetScannedAddress(std::string name);
+    DWORD GetScannedAddress(std::string name);
     bool HasFound(std::string name);
+    bool HasFoundAll() const;
 
 private:
     struct Signature {
@@ -49,5 +51,6 @@ private:
     std::unordered_map<std::string, DWORD> found_sigs{};
     std::vector<Signature> sigs_to_find{};
     std::string module_to_scan{};
+    std::optional<DWORD> GetScannedAddressOpt(std::string name);
 };
 } // namespace MemoryUtil

--- a/Game/SigScanner.h
+++ b/Game/SigScanner.h
@@ -13,7 +13,7 @@ public:
     explicit SigScanner(const char* mod);
     ~SigScanner();
 
-    void AddNewSignature(const char* _name, const char* _signature, const char* _mask,
+    void AddNewSignature(const char* _name, const char* _signature, std::string _mask,
                          std::size_t _offset = 0);
 
     void Scan();
@@ -26,8 +26,8 @@ public:
 private:
     struct Signature {
         std::string name{};
-        const char* signature{nullptr};
-        const char* mask{nullptr};
+        std::vector<char> signature{};
+        std::string mask{};
         std::size_t sig_length{0};
         std::size_t offset{0};
         Signature() = default;
@@ -38,17 +38,45 @@ private:
         // signature: "\xAA\xBB\xCC\xDD\xEE\xFF"
         // mask: "xx??xx"
         // Will NOT check the bytes \xCC\xDD
-        Signature(std::string _name, const char* _signature, const char* _mask,
+        Signature(std::string _name, const std::vector<char> _signature, std::string _mask,
                   std::size_t _offset = 0) {
             name = _name;
             signature = _signature;
             mask = _mask;
-            sig_length = strlen(_mask);
+            sig_length = _mask.size();
             offset = _offset;
+        }
+
+        inline bool operator==(const Signature& rhs) {
+            return name == rhs.name && sig_length == rhs.sig_length && offset == rhs.offset &&
+                   !strncmp(signature.data(), rhs.signature.data(), sig_length) &&
+                   !strncmp(mask.data(), rhs.mask.data(), sig_length);
+        }
+        inline bool operator!=(const Signature& rhs) {
+            return !operator==(rhs);
         }
     };
 
-    std::unordered_map<std::string, uintptr_t> found_sigs{};
+    struct SignaturePair {
+        Signature signature{};
+        uintptr_t address{};
+    };
+
+    struct CacheSignature {
+        Signature signature{};
+        bool found{};
+        uintptr_t offset_from_base{};
+    };
+
+    struct CacheModule {
+        std::string module_name{};
+        std::vector<CacheSignature> signatures{};
+    };
+
+    void SaveResultToCache(uintptr_t base);
+    std::vector<SigScanner::CacheModule> ReadFromCache();
+
+    std::unordered_map<std::string, SignaturePair> found_sigs{};
     std::vector<Signature> sigs_to_find{};
     std::string module_to_scan{};
     std::optional<uintptr_t> GetScannedAddressOpt(std::string name);

--- a/Game/SigScanner.h
+++ b/Game/SigScanner.h
@@ -19,8 +19,8 @@ public:
     void Scan();
     void Reset();
 
-    DWORD GetScannedAddress(std::string name);
-    bool HasFound(std::string name);
+    uintptr_t GetScannedAddress(std::string_view name);
+    bool HasFound(std::string_view name);
     bool HasFoundAll() const;
 
 private:
@@ -48,9 +48,9 @@ private:
         }
     };
 
-    std::unordered_map<std::string, DWORD> found_sigs{};
+    std::unordered_map<std::string, uintptr_t> found_sigs{};
     std::vector<Signature> sigs_to_find{};
     std::string module_to_scan{};
-    std::optional<DWORD> GetScannedAddressOpt(std::string name);
+    std::optional<uintptr_t> GetScannedAddressOpt(std::string name);
 };
 } // namespace MemoryUtil

--- a/Game/ld32.c
+++ b/Game/ld32.c
@@ -1,0 +1,95 @@
+/*
+x86 Length Disassembler.
+Copyright (C) 2013 Byron Platt
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+https://github.com/greenbender/lend
+*/
+
+#include "ld32.h"
+
+/* length_disasm */
+unsigned int length_disasm(void* opcode0) {
+
+    unsigned char* opcode = opcode0;
+
+    unsigned int flag = 0;
+    unsigned int ddef = 4, mdef = 4;
+    unsigned int msize = 0, dsize = 0;
+
+    unsigned char op, modrm, mod, rm;
+
+prefix:
+    op = *opcode++;
+
+    /* prefix */
+    if (CHECK_PREFIX(op)) {
+        if (CHECK_PREFIX_66(op))
+            ddef = 2;
+        else if (CHECK_PREFIX_67(op))
+            mdef = 2;
+        goto prefix;
+    }
+
+    /* two byte opcode */
+    if (CHECK_0F(op)) {
+        op = *opcode++;
+        if (CHECK_MODRM2(op))
+            flag++;
+        if (CHECK_DATA12(op))
+            dsize++;
+        if (CHECK_DATA662(op))
+            dsize += ddef;
+    }
+
+    /* one byte opcode */
+    else {
+        if (CHECK_MODRM(op))
+            flag++;
+        if (CHECK_TEST(op) && !(*opcode & 0x38))
+            dsize += (op & 1) ? ddef : 1;
+        if (CHECK_DATA1(op))
+            dsize++;
+        if (CHECK_DATA2(op))
+            dsize += 2;
+        if (CHECK_DATA66(op))
+            dsize += ddef;
+        if (CHECK_MEM67(op))
+            msize += mdef;
+    }
+
+    /* modrm */
+    if (flag) {
+        modrm = *opcode++;
+        mod = modrm & 0xc0;
+        rm = modrm & 0x07;
+        if (mod != 0xc0) {
+            if (mod == 0x40)
+                msize++;
+            if (mod == 0x80)
+                msize += mdef;
+            if (mdef == 2) {
+                if ((mod == 0x00) && (rm == 0x06))
+                    msize += 2;
+            } else {
+                if (rm == 0x04)
+                    rm = *opcode++ & 0x07;
+                if (rm == 0x05 && mod == 0x00)
+                    msize += 4;
+            }
+        }
+    }
+
+    opcode += msize + dsize;
+
+    return opcode - (unsigned char*)opcode0;
+}

--- a/Game/ld32.h
+++ b/Game/ld32.h
@@ -1,0 +1,249 @@
+/*
+x86 Length Disassembler.
+Copyright (C) 2013 Byron Platt
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+https://github.com/greenbender/lend
+*/
+
+#ifndef __LD32_H__
+#define __LD32_H__
+
+/* implemented tables */
+#define PREFIX_T 1
+#define MODRM2_T 2
+#define MODRM_T 4
+#define DATA1_T 8
+#define DATA2_T 16
+#define DATA66_T 32
+
+/* configure tables */
+#ifndef USE_T
+#define USE_T (MODRM2_T | MODRM_T | DATA1_T | DATA66_T)
+#endif
+
+/* length_disasm */
+unsigned int length_disasm(void* opcode0);
+
+/* table macros */
+#ifdef USE_T
+#define BITMASK32(b00, b01, b02, b03, b04, b05, b06, b07, b08, b09, b0a, b0b, b0c, b0d, b0e, b0f,  \
+                  b10, b11, b12, b13, b14, b15, b16, b17, b18, b19, b1a, b1b, b1c, b1d, b1e, b1f)  \
+    ((b00 << 0x00) | (b01 << 0x01) | (b02 << 0x02) | (b03 << 0x03) | (b04 << 0x04) |               \
+     (b05 << 0x05) | (b06 << 0x06) | (b07 << 0x07) | (b08 << 0x08) | (b09 << 0x09) |               \
+     (b0a << 0x0a) | (b0b << 0x0b) | (b0c << 0x0c) | (b0d << 0x0d) | (b0e << 0x0e) |               \
+     (b0f << 0x0f) | (b10 << 0x10) | (b11 << 0x11) | (b12 << 0x12) | (b13 << 0x13) |               \
+     (b14 << 0x14) | (b15 << 0x15) | (b16 << 0x16) | (b17 << 0x17) | (b18 << 0x18) |               \
+     (b19 << 0x19) | (b1a << 0x1a) | (b1b << 0x1b) | (b1c << 0x1c) | (b1d << 0x1d) |               \
+     (b1e << 0x1e) | (b1f << 0x1f))
+#define CHECK_TABLE(t, v) ((t[(v) >> 5] >> ((v)&0x1f)) & 1)
+#endif
+
+/* CHECK_PREFIX */
+#if defined(USE_T) && (USE_T & PREFIX_T)
+const static unsigned int prefix_t[] = {
+    /* 0 1 2 3 4 5 6 7  8 9 a b c d e f */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 0 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* 1 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0,  /* 2 */
+              0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0), /* 3 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 4 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* 5 */
+    BITMASK32(0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,  /* 6 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* 7 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 8 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* 9 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* a */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* b */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* c */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* d */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* e */
+              1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)  /* f */
+};
+#define CHECK_PREFIX(v) CHECK_TABLE(prefix_t, v)
+#else
+#define CHECK_PREFIX(v)                                                                            \
+    (((v)&0xe7) == 0x26 || ((v)&0xfc) == 0x64 || (v) == 0xf0 || (v) == 0xf2 || (v) == 0xf3)
+#endif
+
+/* CHECK_PREFIX_66 */
+#define CHECK_PREFIX_66(v) ((v) == 0x66)
+
+/* CHECK_PREFIX_67 */
+#define CHECK_PREFIX_67(v) ((v) == 0x67)
+
+/* CHECK_0F */
+#define CHECK_0F(v) ((v) == 0x0f)
+
+/* CHECK_MODRM2 */
+#if defined(USE_T) && (USE_T & MODRM2_T)
+const static unsigned int modrm2_t[] = {
+    /* 0 1 2 3 4 5 6 7  8 9 a b c d e f */
+    BITMASK32(1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 0 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 1 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 2 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 3 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 4 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 5 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 6 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 7 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 8 */
+              1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u), /* 9 */
+    BITMASK32(0u, 0u, 0u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 0u, 1u,  /* a */
+              1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 0u, 0u, 1u, 1u, 1u, 1u, 1u, 1u), /* b */
+    BITMASK32(1u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* c */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* d */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* e */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u)  /* f */
+};
+#define CHECK_MODRM2(v) CHECK_TABLE(modrm2_t, v)
+#else
+#define CHECK_MODRM2(v)                                                                            \
+    (__extension__({                                                                               \
+        register BYTE __a = (v)&0xfc, __b = (v)&0xfe;                                              \
+        ((v)&0xf0) == 0x90 || ((v)&0xf8) == 0xb0 || ((v)&0xf6) == 0xa4 || __a == 0x00 ||           \
+            __a == 0xbc || __b == 0xba || __b == 0xc0 || (v) == 0xa3 || (v) == 0xab ||             \
+            (v) == 0xaf;                                                                           \
+    }))
+#endif
+
+/* CHECK_DATA12 */
+#define CHECK_DATA12(v) ((v) == 0xa4 || (v) == 0xac || (v) == 0xba)
+
+/* CHECK_DATA662 */
+#define CHECK_DATA662(v) (((v)&0xf0) == 0x80)
+
+/* CHECK_MODRM */
+#if defined(USE_T) && (USE_T & MODRM_T)
+const static unsigned int modrm_t[] = {
+    /* 0 1 2 3 4 5 6 7  8 9 a b c d e f */
+    BITMASK32(1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u,  /* 0 */
+              1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u), /* 1 */
+    BITMASK32(1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u,  /* 2 */
+              1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u), /* 3 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 4 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 5 */
+    BITMASK32(0u, 0u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 1u, 0u, 0u, 0u, 0u,  /* 6 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 7 */
+    BITMASK32(1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u,  /* 8 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 9 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* a */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* b */
+    BITMASK32(1u, 1u, 0u, 0u, 1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* c */
+              1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u), /* d */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* e */
+              0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u)  /* f */
+};
+#define CHECK_MODRM(v) CHECK_TABLE(modrm_t, v)
+#else
+#define CHECK_MODRM(v)                                                                             \
+    (__extension__({                                                                               \
+        register BYTE __a = (v)&0xfc, __b = (v)&0xfe;                                              \
+        ((v)&0xc4) == 0x00 || ((v)&0xf0) == 0x80 || ((v)&0xf8) == 0xd8 || ((v)&0xf6) == 0xf6 ||    \
+            __a == 0xc4 || __a == 0xd0 || __b == 0x62 || __b == 0xc0 || (v) == 0x69 ||             \
+            (v) == 0x6b;                                                                           \
+    }))
+#endif
+
+/* CHECK_TEST */
+#define CHECK_TEST(v) ((v) == 0xf6 || (v) == 0xf7)
+
+/* CHECK_DATA1 */
+#if defined(USE_T) && (USE_T & DATA1_T)
+const static unsigned int data1_t[] = {
+    /* 0 1 2 3 4 5 6 7  8 9 a b c d e f */
+    BITMASK32(0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u,  /* 0 */
+              0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u), /* 1 */
+    BITMASK32(0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u,  /* 2 */
+              0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u), /* 3 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 4 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 5 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 0u, 0u, 0u, 0u,  /* 6 */
+              1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u), /* 7 */
+    BITMASK32(1u, 0u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 8 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 9 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* a */
+              1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* b */
+    BITMASK32(1u, 1u, 0u, 0u, 0u, 0u, 1u, 0u, 1u, 0u, 0u, 0u, 0u, 1u, 0u, 0u,  /* c */
+              0u, 0u, 0u, 0u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* d */
+    BITMASK32(1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u,  /* e */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u)  /* f */
+};
+#define CHECK_DATA1(v) CHECK_TABLE(data1_t, v)
+#else
+#define CHECK_DATA1(v)                                                                             \
+    (__extension__({                                                                               \
+        register BYTE __a = (v)&0xf8, __b = (v)&0xfe;                                              \
+        ((v)&0xf0) == 0x70 || ((v)&0xc7) == 0x04 || __a == 0xb0 || __a == 0xe0 || __b == 0x6a ||   \
+            __b == 0x82 || __b == 0xc0 || __b == 0xd4 || (v) == 0x80 || (v) == 0xa8 ||             \
+            (v) == 0xc6 || (v) == 0xc8 || (v) == 0xcd || (v) == 0xeb;                              \
+    }))
+#endif
+
+/* CHECK_DATA2 */
+#if defined(USE_T) && (USE_T & DATA2_T)
+const static unsigned int data2_t[] = {
+    /* 0 1 2 3 4 5 6 7  8 9 a b c d e f */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 0 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* 1 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 2 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* 3 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 4 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* 5 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 6 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* 7 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* 8 */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0), /* 9 */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  /* a */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* b */
+    BITMASK32(0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0,  /* c */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), /* d */
+    BITMASK32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,  /* e */
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)  /* f */
+};
+#define CHECK_DATA2(v) CHECK_TABLE(data2_t, v)
+#else
+#define CHECK_DATA2(v) ((v) == 0x9a || (v) == 0xc2 || (v) == 0xc8 || (v) == 0xca || (v) == 0xea)
+#endif
+
+/* CHECK_DATA66 */
+#if defined(USE_T) && (USE_T & DATA66_T)
+const static unsigned int data66_t[] = {
+    /* 0 1 2 3 4 5 6 7  8 9 a b c d e f */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u,  /* 0 */
+              0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u), /* 1 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u,  /* 2 */
+              0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u), /* 3 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 4 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 5 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 6 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* 7 */
+    BITMASK32(0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* 8 */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u), /* 9 */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u,  /* a */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u, 1u, 1u, 1u, 1u), /* b */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u,  /* c */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u), /* d */
+    BITMASK32(0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 0u, 0u, 0u, 0u, 0u,  /* e */
+              0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u)  /* f */
+};
+#define CHECK_DATA66(v) CHECK_TABLE(data66_t, v)
+#else
+#define CHECK_DATA66(v)                                                                            \
+    (((v)&0xc7) == 0x05 || ((v)&0xf8) == 0xb8 || ((v)&0x7e) == 0x68 || (v) == 0x81 ||              \
+     (v) == 0x9a || (v) == 0xa9 || (v) == 0xc7 || (v) == 0xea)
+#endif
+
+/* CHECK_MEM67 */
+#define CHECK_MEM67(v) (((v)&0xfc) == 0xa0)
+
+#endif

--- a/Game/main.cpp
+++ b/Game/main.cpp
@@ -4,75 +4,12 @@
 #include <vector>
 #include <Windows.h>
 #include <psapi.h>
+#include "Common.h"
 #include "EnginePatches.h"
 #include "MemoryUtil.h"
 #include "SigScanner.h"
 
-#define LOG(x) MessageBox(NULL, x, "RGSSAD Container", MB_ICONERROR)
-
 constexpr bool PATCH_KEY_AND_HEADER = false;
-
-constexpr std::array<char, 8> PATCHED_HEADER{'\x31', '\xac', '\x3e', '\x2d',
-                                             '\x9b', '\x23', '\xda', '\x11'};
-constexpr unsigned int NEW_KEY = 0xBCF33B95;
-
-// If we're running from a debugger or within MSVC, we'll get a debugger is attached error. We
-// patch out the IsDebuggerPresent() check just to allow the ability to debug
-void PatchDebugPresent() {
-    const auto kernel32 = GetModuleHandle("Kernel32.dll");
-    if (kernel32 == 0) {
-        return;
-    }
-    auto addr = GetProcAddress(kernel32, "IsDebuggerPresent");
-    if (addr == 0) {
-        return;
-    }
-
-    // EAX stores the return of IsDebuggerPresent()
-    std::array<char, 3> patch{
-        '\x31', '\xC0', // xor eax, eax
-        '\xC3'          // ret
-    };
-    MemoryUtil::PatchBytes(reinterpret_cast<DWORD>(addr), patch.data(), patch.size());
-}
-
-void SwapRgssadEncryption(const char* library_path) {
-    MemoryUtil::SigScanner scanner(library_path);
-    // Locate the RGSSAD header to change the bytes to something else. The fields for the header are
-    // not actually meaningful and are just checked against a block of memory to make sure they
-    // match
-    scanner.AddNewSignature(
-        "RGSSAD_Header",
-        "\x52\x00\x00\x00\x47\x00\x00\x00\x53\x00\x00\x00\x53\x00\x00\x00\x41\x00\x00"
-        "\x00\x44\x00\x00\x00\x00\x00\x00\x00\x01",
-        "x???x???x???x???x???x???x???x");
-
-    // Locate the base RGSSAD encryption key
-    scanner.AddNewSignature("RGSSAD_Key", "\xFE\xCA\xAD\xDE", "xxxx");
-
-    scanner.Scan();
-
-    // Only sig patch if we've found both the header and the key
-    if (scanner.HasFound("RGSSAD_Header") && scanner.HasFound("RGSSAD_Key")) {
-        auto header_address = scanner.GetScannedAddress("RGSSAD_Header");
-        auto key_address = scanner.GetScannedAddress("RGSSAD_Key");
-
-        // Copy our new header bytes and write
-        std::array<char, 32> header;
-        std::memcpy(header.data(), reinterpret_cast<void*>(header_address), header.size());
-        for (std::size_t i = 0; i < PATCHED_HEADER.size(); i++) {
-            header[i * 4] = PATCHED_HEADER[i];
-        }
-
-        // Overwrite the header to the new header
-        MemoryUtil::PatchBytes(header_address, header.data(), header.size());
-
-        // Change the encryption key used for """decrypting""" RGSSADs
-        MemoryUtil::PatchType<unsigned int>(key_address, NEW_KEY);
-    } else {
-        LOG("Incorrect RGSSAD dll supplied!");
-    }
-}
 
 using RGSSInitializeProc = void (*)(HINSTANCE);
 using RGSSFinalizeProc = void (*)(void);
@@ -130,6 +67,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     char rgssad_path[0x200];
     char dll_path[0x200];
+    char cache_file[0x200];
 
     GetPrivateProfileString("Game", "Library", NULL, library_path, MAX_PATH, game_config.c_str());
     GetPrivateProfileString("Game", "Title", "RGSSAD Container", game_title, 0x200,
@@ -141,13 +79,16 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     GetPrivateProfileString("Container", "Dlls", "", dll_path, 0x200, game_config.c_str());
     GetPrivateProfileString("Container", "RGSSAD", "Game.rgssad", rgssad_path, 0x200,
                             game_config.c_str());
+    GetPrivateProfileString("Container", "SignatureCache", "sig_cache.che", cache_file, 0x200,
+                            game_config.c_str());
+
     const auto fast_boot =
         GetPrivateProfileInt("Container", "FastBoot", 0, game_config.c_str()) > 0;
     const auto allow_debugger =
         GetPrivateProfileInt("Container", "AllowDebugger", 0, game_config.c_str()) > 0;
 
     if (allow_debugger) {
-        PatchDebugPresent();
+        Patches::PatchDebugPresent();
     }
 
     // With the custom container, we can reroute where DLLs are stored, this lets us cleanup the
@@ -237,7 +178,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     // If we want to patch the rgssad, start patching
     if (PATCH_KEY_AND_HEADER) {
-        SwapRgssadEncryption(library_path);
+        Patches::SwapRgssadEncryption(library_path);
     }
 
     // RGSSAD Level patches

--- a/Game/main.cpp
+++ b/Game/main.cpp
@@ -24,11 +24,15 @@ RGSSEvalProc RGSSEval = nullptr;
 RGSSSetupRTPProc RGSSSetupRTP = nullptr;
 
 bool GetRGSSExports(HMODULE rgssad) {
-    RGSSInitialize = reinterpret_cast<RGSSInitializeProc>(GetProcAddress(rgssad, "RGSSInitialize"));
-    RGSSFinalize = reinterpret_cast<RGSSFinalizeProc>(GetProcAddress(rgssad, "RGSSFinalize"));
-    RGSSGameMain = reinterpret_cast<RGSSGameMainProc>(GetProcAddress(rgssad, "RGSSGameMain"));
-    RGSSEval = reinterpret_cast<RGSSEvalProc>(GetProcAddress(rgssad, "RGSSEval"));
-    RGSSSetupRTP = reinterpret_cast<RGSSSetupRTPProc>(GetProcAddress(rgssad, "RGSSSetupRTP"));
+    RGSSInitialize =
+        MemoryUtil::MakeCallable<RGSSInitializeProc>(GetProcAddress(rgssad, "RGSSInitialize"));
+    RGSSFinalize =
+        MemoryUtil::MakeCallable<RGSSFinalizeProc>(GetProcAddress(rgssad, "RGSSFinalize"));
+    RGSSGameMain =
+        MemoryUtil::MakeCallable<RGSSGameMainProc>(GetProcAddress(rgssad, "RGSSGameMain"));
+    RGSSEval = MemoryUtil::MakeCallable<RGSSEvalProc>(GetProcAddress(rgssad, "RGSSEval"));
+    RGSSSetupRTP =
+        MemoryUtil::MakeCallable<RGSSSetupRTPProc>(GetProcAddress(rgssad, "RGSSSetupRTP"));
 
     return RGSSInitialize != nullptr && RGSSFinalize != nullptr && RGSSGameMain != nullptr &&
            RGSSEval != nullptr && RGSSSetupRTP != nullptr;

--- a/Game/main.cpp
+++ b/Game/main.cpp
@@ -10,6 +10,7 @@
 #include "SigScanner.h"
 
 constexpr bool PATCH_KEY_AND_HEADER = false;
+constexpr bool PATCH_CUSTOM_MODULES = false;
 
 using RGSSInitializeProc = void (*)(HINSTANCE);
 using RGSSFinalizeProc = void (*)(void);
@@ -186,8 +187,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     }
 
     // RGSSAD Level patches
-    Patches::SetupDetours(library_path);
-
+    if (PATCH_CUSTOM_MODULES) {
+        Patches::SetupDetours(library_path);
+    }
     // Get the exports from the RGSS dll
     if (!GetRGSSExports(rgssad_library)) {
         LOG("Failed to load RGSSAD library!");


### PR DESCRIPTION
Engine patching allows us to detour any function as we please in the RGSSAD dll. This is mainly preliminary work. Currently what's done is:

- Ability to detour functions
- Ability to perform mid function hooks(untested)
- Ability to call any engine function as long as the address and prototypes are known
- Ability to create new ruby modules(See AriMath as an example)

A few things will need to be fixed, ~~currently, the ruby wrapper uses a singleton which will need to be reworked to be avoided~~ (No nice way to do this due to how ruby modules work). A ~~custom reimplementation of the RGSSAD archive loader~~ (Out of scope, will be in a separate PR) is a goal, however, more research needs to be done on grabbing the current Standard RTP path for any missing files in the archive.