### PR TITLE
Add out of focus patch to allow the game to run out of focus

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,88 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^\<[^Q][^/.>]*\>'
+    Priority:        -2
+  - Regex:           '^\<'
+    Priority:        -1
+  - Regex:           '^\"'
+    Priority:        0
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 150
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...

--- a/Game/EnginePatches.h
+++ b/Game/EnginePatches.h
@@ -11,5 +11,6 @@ void GrabGameClassAddress(const char* library_path);
 void SetupDetours(const char* library_path);
 void SwapRgssadEncryption(const char* library_path);
 void PatchBindings(const char* library_path);
+void RunOutOfFocus(const char* library_path);
 void PatchDebugPresent();
 } // namespace Patches

--- a/Game/main.cpp
+++ b/Game/main.cpp
@@ -93,6 +93,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     const auto allow_debugger =
         GetPrivateProfileInt("Container", "AllowDebugger", 0, game_config.c_str()) > 0;
 
+    const auto run_out_of_focus =
+        GetPrivateProfileInt("Container", "AllowOutOfFocus", 0, game_config.c_str()) > 0;
+
     if (allow_debugger) {
         Patches::PatchDebugPresent();
     }
@@ -180,6 +183,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             LOG(error.c_str());
         }
         return 1;
+    }
+
+    if (run_out_of_focus) {
+        Patches::RunOutOfFocus(library_path);
     }
 
     Patches::GrabGameClassAddress(library_path);

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ RGSSAD=Game.rgssad
 FastBoot=1
 AllowDebugger=0
 Dlls=
+AllowOutOfFocus=0
 ```
 4. Make any changes as needed
 
@@ -45,6 +46,10 @@ Allow debugger patches `IsDebuggerPresent()` to allow a debugger to be attached 
 ### DLLs
 
 Dlls lets you set a new directory for where to scan for newly loaded DLLs. This is typically useful if you have a lot of DLLs and you want to keep your main directory clean so users can easily find where to run the game.
+
+### AllowOutOfFocus
+
+This allows the game to continue running as if the window is active. This means the window doesn't need to be in focus for the game to actually work
 
 ## Building
 Build using Visual Studio 2019


### PR DESCRIPTION
By doing a memory patch of: 
```
.text:10005281 8B 4D 10                                                        mov     ecx, [ebp+wParam]
.text:10005284 89 88 14 01 00 00                                               mov     [eax+114h], ecx
```

We can now allow the game to continue execution even when out of focus